### PR TITLE
Serve simulator UI from API and update Cesium token

### DIFF
--- a/astroyd-meteor-madness-main/README.md
+++ b/astroyd-meteor-madness-main/README.md
@@ -35,10 +35,18 @@ cp env.example .env
 # echo "NASA_API_KEY=YOUR_KEY" >> .env.local
 ```
 
-3. Run the application:
+3. Run the backend API:
 ```bash
 uvicorn app.main:app --reload
 ```
+
+4. Serve the frontend:
+   - **Easiest:** the API process now exposes the UI at `/ui`, so once the backend is running you can browse to `http://127.0.0.1:8000/ui/`.
+   - **Optional standalone host:**
+     ```bash
+     uvicorn app.frontend:app --host 0.0.0.0 --port 4173
+     ```
+     The JavaScript client auto-detects the backend URL, so you can open `http://127.0.0.1:4173/` without editing any configuration.
 
 ### Environment Variables
 

--- a/astroyd-meteor-madness-main/api-client.js
+++ b/astroyd-meteor-madness-main/api-client.js
@@ -1,9 +1,85 @@
 // API client for Meteor Madness backend
-const API_BASE_URL = 'http://localhost:8000/api/v1';
+const deriveApiBaseUrl = () => {
+    if (typeof window === 'undefined') {
+        return 'http://localhost:8000/api/v1';
+    }
+
+    const override = window.__METEOR_MADNESS_API__?.baseUrl;
+    if (override) {
+        return override.replace(/\/$/, '');
+    }
+
+    const { protocol, hostname, port } = window.location;
+
+    if (port === '4173') {
+        return `${protocol}//${hostname}:8000/api/v1`;
+    }
+
+    const portSegment = port ? `:${port}` : '';
+    return `${protocol}//${hostname}${portSegment}/api/v1`;
+};
+
+const API_BASE_URL = deriveApiBaseUrl();
 
 class MeteorMadnessAPI {
     constructor() {
         this.baseURL = API_BASE_URL;
+    }
+
+    _getAuthToken() {
+        try {
+            return window.localStorage?.getItem('meteorMadnessToken');
+        } catch (error) {
+            console.warn('Unable to access localStorage for auth token:', error);
+            return null;
+        }
+    }
+
+    _getRefreshToken() {
+        try {
+            return window.localStorage?.getItem('meteorMadnessRefreshToken');
+        } catch (error) {
+            console.warn('Unable to access localStorage for refresh token:', error);
+            return null;
+        }
+    }
+
+    _setAuthToken(token) {
+        try {
+            if (token) {
+                window.localStorage?.setItem('meteorMadnessToken', token);
+            } else {
+                window.localStorage?.removeItem('meteorMadnessToken');
+            }
+        } catch (error) {
+            console.warn('Unable to persist auth token:', error);
+        }
+    }
+
+    _setRefreshToken(token) {
+        try {
+            if (token) {
+                window.localStorage?.setItem('meteorMadnessRefreshToken', token);
+            } else {
+                window.localStorage?.removeItem('meteorMadnessRefreshToken');
+            }
+        } catch (error) {
+            console.warn('Unable to persist refresh token:', error);
+        }
+    }
+
+    clearStoredTokens() {
+        this._setAuthToken(null);
+        this._setRefreshToken(null);
+    }
+
+    _buildHeaders(base = {}) {
+        const headers = { ...base };
+        const token = this._getAuthToken();
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+        return headers;
     }
 
     async simulateImpact(asteroidData, impactLocation, options = {}) {
@@ -13,6 +89,7 @@ class MeteorMadnessAPI {
                     diameter: asteroidData.diameter || asteroidData.size,
                     mass: asteroidData.mass,
                     velocity: asteroidData.velocity || asteroidData.speed,
+                    impact_angle: asteroidData.impact_angle || asteroidData.impactAngle || 45,
                     density: asteroidData.density,
                     composition: asteroidData.composition || "iron"
                 },
@@ -29,11 +106,18 @@ class MeteorMadnessAPI {
                 deflection_method: options.deflectionMethod || "none"
             };
 
+            if (typeof options.calculateTrajectory === 'boolean') {
+                requestData.calculate_trajectory = options.calculateTrajectory;
+            }
+            if (typeof options.includeZones === 'boolean') {
+                requestData.include_zones = options.includeZones;
+            }
+
             const response = await fetch(`${this.baseURL}/simulation/simulate`, {
                 method: 'POST',
-                headers: {
+                headers: this._buildHeaders({
                     'Content-Type': 'application/json',
-                },
+                }),
                 body: JSON.stringify(requestData)
             });
 
@@ -44,6 +128,100 @@ class MeteorMadnessAPI {
             return await response.json();
         } catch (error) {
             console.error('Error calling simulation API:', error);
+            throw error;
+        }
+    }
+
+    async registerUser(userData) {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/register`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(userData)
+            });
+
+            if (!response.ok) {
+                const detail = await response.json().catch(() => ({}));
+                throw new Error(detail.detail || `Registration failed: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error registering user:', error);
+            throw error;
+        }
+    }
+
+    async loginUser(credentials) {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/login`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(credentials)
+            });
+
+            if (!response.ok) {
+                const detail = await response.json().catch(() => ({}));
+                throw new Error(detail.detail || `Login failed: ${response.status}`);
+            }
+
+            const tokens = await response.json();
+            this._setAuthToken(tokens.access_token);
+            this._setRefreshToken(tokens.refresh_token);
+            return tokens;
+        } catch (error) {
+            console.error('Error logging in:', error);
+            throw error;
+        }
+    }
+
+    async refreshAccessToken() {
+        const refreshToken = this._getRefreshToken();
+        if (!refreshToken) {
+            throw new Error('No refresh token available');
+        }
+
+        const response = await fetch(`${this.baseURL}/auth/refresh`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ refresh_token: refreshToken })
+        });
+
+        if (!response.ok) {
+            this.clearStoredTokens();
+            throw new Error(`Refresh failed: ${response.status}`);
+        }
+
+        const tokens = await response.json();
+        this._setAuthToken(tokens.access_token);
+        this._setRefreshToken(tokens.refresh_token);
+        return tokens;
+    }
+
+    async getProfile() {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/me`, {
+                headers: this._buildHeaders({ 'Accept': 'application/json' })
+            });
+
+            if (response.status === 401) {
+                this.clearStoredTokens();
+                throw new Error('Authentication required');
+            }
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error fetching profile:', error);
             throw error;
         }
     }
@@ -82,8 +260,10 @@ class MeteorMadnessAPI {
 
     async getSolutions() {
         try {
-            const response = await fetch(`${this.baseURL}/simulation/solutions`);
-            
+            const response = await fetch(`${this.baseURL}/simulation/solutions`, {
+                headers: this._buildHeaders(),
+            });
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
@@ -99,9 +279,9 @@ class MeteorMadnessAPI {
         try {
             const response = await fetch(`${this.baseURL}/simulation/deflection-game/submit-score`, {
                 method: 'POST',
-                headers: {
+                headers: this._buildHeaders({
                     'Content-Type': 'application/json',
-                },
+                }),
                 body: JSON.stringify(scoreData)
             });
 
@@ -118,8 +298,10 @@ class MeteorMadnessAPI {
 
     async getDeflectionLeaderboard() {
         try {
-            const response = await fetch(`${this.baseURL}/simulation/deflection-game/leaderboard`);
-            
+            const response = await fetch(`${this.baseURL}/simulation/deflection-game/leaderboard`, {
+                headers: this._buildHeaders(),
+            });
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
@@ -131,10 +313,33 @@ class MeteorMadnessAPI {
         }
     }
 
+    async getSimulationHistory(params = {}) {
+        try {
+            const queryParams = new URLSearchParams(params);
+            const response = await fetch(`${this.baseURL}/simulation/history?${queryParams.toString()}`, {
+                headers: this._buildHeaders(),
+            });
+
+            if (response.status === 401) {
+                this.clearStoredTokens();
+                throw new Error('Authentication required');
+            }
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error fetching simulation history:', error);
+            throw error;
+        }
+    }
+
     async getVersion() {
         try {
             const response = await fetch('http://localhost:8000/version');
-            
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }

--- a/astroyd-meteor-madness-main/app/core/auth.py
+++ b/astroyd-meteor-madness-main/app/core/auth.py
@@ -6,8 +6,9 @@ from datetime import datetime, timedelta
 from typing import Optional, Union
 from jose import JWTError, jwt
 from passlib.context import CryptContext
-from fastapi import HTTPException, status, Depends
+from fastapi import HTTPException, status, Depends, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security.utils import get_authorization_scheme_param
 from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.database import get_db
@@ -18,7 +19,15 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+try:
+    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    # Probe hashing to ensure the backend is available at runtime
+    pwd_context.hash("healthcheck")
+except Exception as exc:  # pragma: no cover - fallback for restricted environments
+    logger.warning(
+        "bcrypt backend unavailable (%s); falling back to pbkdf2_sha256 hashing", exc
+    )
+    pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 # JWT settings
 SECRET_KEY = settings.SECRET_KEY
@@ -101,8 +110,33 @@ def get_current_user(
     user = db.query(User).filter(User.username == username).first()
     if user is None:
         raise credentials_exception
-    
+
     return user
+
+
+def get_current_user_optional(
+    request: Request,
+    db: Session = Depends(get_db)
+) -> Optional[User]:
+    """Return the authenticated user if a valid bearer token is supplied."""
+
+    authorization: str | None = request.headers.get("Authorization")
+    if not authorization:
+        return None
+
+    scheme, token = get_authorization_scheme_param(authorization)
+    if not token or scheme.lower() != "bearer":
+        return None
+
+    payload = verify_token(token)
+    if not payload or payload.get("type") != "access":
+        return None
+
+    username: str | None = payload.get("sub")
+    if not username:
+        return None
+
+    return db.query(User).filter(User.username == username).first()
 
 def get_current_active_user(current_user: User = Depends(get_current_user)) -> User:
     """Get current active user"""

--- a/astroyd-meteor-madness-main/app/core/database.py
+++ b/astroyd-meteor-madness-main/app/core/database.py
@@ -3,9 +3,10 @@ Enhanced database configuration with all models
 """
 
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
 from app.core.config import settings
+from app.core.models import Base
 
 # Create database engine
 engine = create_engine(
@@ -17,9 +18,6 @@ engine = create_engine(
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# Base class for models
-Base = declarative_base()
-
 def get_db():
     """Dependency to get database session"""
     db = SessionLocal()
@@ -30,12 +28,9 @@ def get_db():
 
 def create_tables():
     """Create all database tables"""
-    # Import all models to ensure they're registered
-    from app.core.models import (
-        User, Simulation, DeflectionGameScoreDB, 
-        SimulationExport, UserSession, SystemLog
-    )
-    
+    # Import models to ensure metadata is populated before table creation
+    from app.core import models  # noqa: F401  # pylint: disable=unused-import
+
     Base.metadata.create_all(bind=engine)
 
 def drop_tables():

--- a/astroyd-meteor-madness-main/app/frontend.py
+++ b/astroyd-meteor-madness-main/app/frontend.py
@@ -1,0 +1,37 @@
+"""Standalone FastAPI app for serving the static simulator frontend."""
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+
+def _resolve_frontend_root() -> Path:
+    """Return the directory containing the bundled frontend assets."""
+    return Path(__file__).resolve().parent.parent
+
+
+FRONTEND_ROOT = _resolve_frontend_root()
+INDEX_FILE = FRONTEND_ROOT / "index.html"
+
+if not INDEX_FILE.exists():
+    raise RuntimeError(
+        f"Frontend index.html not found. Expected it at {INDEX_FILE}"
+    )
+
+app = FastAPI(
+    title="Meteor Simulator Frontend",
+    description="Static asset server for the Meteor Madness simulator UI.",
+    version="1.0.0",
+)
+
+app.mount(
+    "/",
+    StaticFiles(directory=str(FRONTEND_ROOT), html=True),
+    name="frontend",
+)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    import uvicorn
+
+    uvicorn.run("app.frontend:app", host="0.0.0.0", port=4173, reload=False)

--- a/astroyd-meteor-madness-main/app/main.py
+++ b/astroyd-meteor-madness-main/app/main.py
@@ -1,10 +1,11 @@
-"""
-Main FastAPI application entry point
-"""
+"""Main FastAPI application entry point."""
+
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 import uvicorn
 import os
 from dotenv import load_dotenv
@@ -41,6 +42,18 @@ app.add_middleware(
 
 # Include API routes
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
+# Serve the bundled frontend from within the API process so review environments
+# only require a single Uvicorn instance.
+_frontend_root = Path(__file__).resolve().parent.parent
+_frontend_index = _frontend_root / "index.html"
+
+if _frontend_index.exists():
+    app.mount(
+        "/ui",
+        StaticFiles(directory=str(_frontend_root), html=True),
+        name="meteor-madness-ui",
+    )
 
 @app.get("/")
 async def root():

--- a/astroyd-meteor-madness-main/astroyd-meteor-madness-main/api-client.js
+++ b/astroyd-meteor-madness-main/astroyd-meteor-madness-main/api-client.js
@@ -1,9 +1,85 @@
 // API client for Meteor Madness backend
-const API_BASE_URL = 'http://localhost:8000/api/v1';
+const deriveApiBaseUrl = () => {
+    if (typeof window === 'undefined') {
+        return 'http://localhost:8000/api/v1';
+    }
+
+    const override = window.__METEOR_MADNESS_API__?.baseUrl;
+    if (override) {
+        return override.replace(/\/$/, '');
+    }
+
+    const { protocol, hostname, port } = window.location;
+
+    if (port === '4173') {
+        return `${protocol}//${hostname}:8000/api/v1`;
+    }
+
+    const portSegment = port ? `:${port}` : '';
+    return `${protocol}//${hostname}${portSegment}/api/v1`;
+};
+
+const API_BASE_URL = deriveApiBaseUrl();
 
 class MeteorMadnessAPI {
     constructor() {
         this.baseURL = API_BASE_URL;
+    }
+
+    _getAuthToken() {
+        try {
+            return window.localStorage?.getItem('meteorMadnessToken');
+        } catch (error) {
+            console.warn('Unable to access localStorage for auth token:', error);
+            return null;
+        }
+    }
+
+    _getRefreshToken() {
+        try {
+            return window.localStorage?.getItem('meteorMadnessRefreshToken');
+        } catch (error) {
+            console.warn('Unable to access localStorage for refresh token:', error);
+            return null;
+        }
+    }
+
+    _setAuthToken(token) {
+        try {
+            if (token) {
+                window.localStorage?.setItem('meteorMadnessToken', token);
+            } else {
+                window.localStorage?.removeItem('meteorMadnessToken');
+            }
+        } catch (error) {
+            console.warn('Unable to persist auth token:', error);
+        }
+    }
+
+    _setRefreshToken(token) {
+        try {
+            if (token) {
+                window.localStorage?.setItem('meteorMadnessRefreshToken', token);
+            } else {
+                window.localStorage?.removeItem('meteorMadnessRefreshToken');
+            }
+        } catch (error) {
+            console.warn('Unable to persist refresh token:', error);
+        }
+    }
+
+    clearStoredTokens() {
+        this._setAuthToken(null);
+        this._setRefreshToken(null);
+    }
+
+    _buildHeaders(base = {}) {
+        const headers = { ...base };
+        const token = this._getAuthToken();
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+        return headers;
     }
 
     async simulateImpact(asteroidData, impactLocation, options = {}) {
@@ -13,6 +89,7 @@ class MeteorMadnessAPI {
                     diameter: asteroidData.diameter || asteroidData.size,
                     mass: asteroidData.mass,
                     velocity: asteroidData.velocity || asteroidData.speed,
+                    impact_angle: asteroidData.impact_angle || asteroidData.impactAngle || 45,
                     density: asteroidData.density,
                     composition: asteroidData.composition || "iron"
                 },
@@ -29,11 +106,18 @@ class MeteorMadnessAPI {
                 deflection_method: options.deflectionMethod || "none"
             };
 
+            if (typeof options.calculateTrajectory === 'boolean') {
+                requestData.calculate_trajectory = options.calculateTrajectory;
+            }
+            if (typeof options.includeZones === 'boolean') {
+                requestData.include_zones = options.includeZones;
+            }
+
             const response = await fetch(`${this.baseURL}/simulation/simulate`, {
                 method: 'POST',
-                headers: {
+                headers: this._buildHeaders({
                     'Content-Type': 'application/json',
-                },
+                }),
                 body: JSON.stringify(requestData)
             });
 
@@ -44,6 +128,100 @@ class MeteorMadnessAPI {
             return await response.json();
         } catch (error) {
             console.error('Error calling simulation API:', error);
+            throw error;
+        }
+    }
+
+    async registerUser(userData) {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/register`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(userData)
+            });
+
+            if (!response.ok) {
+                const detail = await response.json().catch(() => ({}));
+                throw new Error(detail.detail || `Registration failed: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error registering user:', error);
+            throw error;
+        }
+    }
+
+    async loginUser(credentials) {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/login`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(credentials)
+            });
+
+            if (!response.ok) {
+                const detail = await response.json().catch(() => ({}));
+                throw new Error(detail.detail || `Login failed: ${response.status}`);
+            }
+
+            const tokens = await response.json();
+            this._setAuthToken(tokens.access_token);
+            this._setRefreshToken(tokens.refresh_token);
+            return tokens;
+        } catch (error) {
+            console.error('Error logging in:', error);
+            throw error;
+        }
+    }
+
+    async refreshAccessToken() {
+        const refreshToken = this._getRefreshToken();
+        if (!refreshToken) {
+            throw new Error('No refresh token available');
+        }
+
+        const response = await fetch(`${this.baseURL}/auth/refresh`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ refresh_token: refreshToken })
+        });
+
+        if (!response.ok) {
+            this.clearStoredTokens();
+            throw new Error(`Refresh failed: ${response.status}`);
+        }
+
+        const tokens = await response.json();
+        this._setAuthToken(tokens.access_token);
+        this._setRefreshToken(tokens.refresh_token);
+        return tokens;
+    }
+
+    async getProfile() {
+        try {
+            const response = await fetch(`${this.baseURL}/auth/me`, {
+                headers: this._buildHeaders({ 'Accept': 'application/json' })
+            });
+
+            if (response.status === 401) {
+                this.clearStoredTokens();
+                throw new Error('Authentication required');
+            }
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error fetching profile:', error);
             throw error;
         }
     }
@@ -82,8 +260,10 @@ class MeteorMadnessAPI {
 
     async getSolutions() {
         try {
-            const response = await fetch(`${this.baseURL}/simulation/solutions`);
-            
+            const response = await fetch(`${this.baseURL}/simulation/solutions`, {
+                headers: this._buildHeaders(),
+            });
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
@@ -99,9 +279,9 @@ class MeteorMadnessAPI {
         try {
             const response = await fetch(`${this.baseURL}/simulation/deflection-game/submit-score`, {
                 method: 'POST',
-                headers: {
+                headers: this._buildHeaders({
                     'Content-Type': 'application/json',
-                },
+                }),
                 body: JSON.stringify(scoreData)
             });
 
@@ -118,8 +298,10 @@ class MeteorMadnessAPI {
 
     async getDeflectionLeaderboard() {
         try {
-            const response = await fetch(`${this.baseURL}/simulation/deflection-game/leaderboard`);
-            
+            const response = await fetch(`${this.baseURL}/simulation/deflection-game/leaderboard`, {
+                headers: this._buildHeaders(),
+            });
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
@@ -131,10 +313,33 @@ class MeteorMadnessAPI {
         }
     }
 
+    async getSimulationHistory(params = {}) {
+        try {
+            const queryParams = new URLSearchParams(params);
+            const response = await fetch(`${this.baseURL}/simulation/history?${queryParams.toString()}`, {
+                headers: this._buildHeaders(),
+            });
+
+            if (response.status === 401) {
+                this.clearStoredTokens();
+                throw new Error('Authentication required');
+            }
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error fetching simulation history:', error);
+            throw error;
+        }
+    }
+
     async getVersion() {
         try {
             const response = await fetch('http://localhost:8000/version');
-            
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }

--- a/astroyd-meteor-madness-main/astroyd-meteor-madness-main/cesium-visualization.js
+++ b/astroyd-meteor-madness-main/astroyd-meteor-madness-main/cesium-visualization.js
@@ -11,7 +11,7 @@ export function setupCesiumVisualization(containerId) {
 }
 
 function runCesium(containerId) {
-  Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyNDMzMTYwMy1hNDI2LTQ0NjAtOGM5MC02OGNhOGIwOGM0ODEiLCJpZCI6MzM4MzI2LCJpYXQiOjE3NTY5ODE5MDl9.MziOOEJHn4bXXuOm-RkxvZ8fD9YgqkOGyfbflKkxjaY';
+  Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI2ODM4NDkyMC04ZDc1LTRkNmYtYjRlNi1hN2YyYTkzYzI1OWIiLCJpZCI6MzM4MzI2LCJpYXQiOjE3NTk1ODMyODN9.8Oh3jFNzuWbGuNUYmt6VewXvFwKuqQwrWoeCw1VfVi8';
   const viewer = new Cesium.Viewer(containerId, {
     terrain: Cesium.Terrain.fromWorldTerrain(),
   });
@@ -46,27 +46,12 @@ function runCesium(containerId) {
   );
 
   // Listen for user input changes
-  window.addEventListener('impactSettingsChanged', (e) => {
-    impact_location = { ...e.detail };
-    impact_result = {
-      blast_radius: impact_location.blast_radius,
-      crater_diameter: impact_location.crater_diameter,
-      thermal_radius: impact_location.thermal_radius,
-      fireball_radius: impact_location.fireball_radius,
-      evacuation_radius: impact_location.evacuation_radius
-    };
-    asteroid_properties = {
-      size: impact_location.asteroid_size || 50,
-      speed: impact_location.asteroid_speed || 20000,
-      mass: impact_location.asteroid_mass || 1000000,
-      density: impact_location.asteroid_density || 3000
-    };
-    impactCartesian = Cesium.Cartesian3.fromDegrees(
-      impact_location.longitude,
-      impact_location.latitude,
-      impact_location.elevation
-    );
-    resetSimulation();
+  window.addEventListener('impactSettingsChanged', (event) => {
+    if (!event || typeof event.detail !== 'object') {
+      resetSimulation();
+      return;
+    }
+    resetSimulation(event.detail);
   });
 
   // Animation cleanup function
@@ -420,7 +405,7 @@ function runCesium(containerId) {
       });
     }
   });
-  function resetSimulation() {
+  function resetSimulation(nextSettings = null) {
     viewer.entities.removeAll();
     state.visualizationEntities.clear();
     state.craterEntities.clear();
@@ -428,13 +413,22 @@ function runCesium(containerId) {
     document.getElementById('toggleButton').style.display = 'none';
     document.getElementById('toggleButton').textContent = 'Show Crater';
     // Always use latest user input
-    impact_location = { ...window.getImpactSettings() };
+    const latestSettings = nextSettings && typeof nextSettings === 'object'
+      ? nextSettings
+      : window.getImpactSettings();
+    impact_location = { ...latestSettings };
     impact_result = {
       blast_radius: impact_location.blast_radius,
       crater_diameter: impact_location.crater_diameter,
       thermal_radius: impact_location.thermal_radius,
       fireball_radius: impact_location.fireball_radius,
       evacuation_radius: impact_location.evacuation_radius
+    };
+    asteroid_properties = {
+      size: impact_location.asteroid_size || 50,
+      speed: impact_location.asteroid_speed || 20000,
+      mass: impact_location.asteroid_mass || 1000000,
+      density: impact_location.asteroid_density || 3000
     };
     impactCartesian = Cesium.Cartesian3.fromDegrees(
       impact_location.longitude,
@@ -456,7 +450,10 @@ function runCesium(containerId) {
       }
     });
   }
-  document.getElementById('launchButton').addEventListener('click', resetSimulation);
+  const launchButton = document.getElementById('launchButton');
+  if (launchButton) {
+    launchButton.addEventListener('click', resetSimulation);
+  }
   // Initial setup
   // resetSimulation(); // Remove this line so asteroid only launches on button click
 }

--- a/astroyd-meteor-madness-main/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/astroyd-meteor-madness-main/index.html
@@ -55,12 +55,132 @@
     #cameraToggleButton:hover {
       background: rgba(0, 153, 255, 0.8);
     }
+
+    #controlPanel {
+      position:absolute;
+      top:10px;
+      right:10px;
+      z-index:2000;
+      background:rgba(255,255,255,0.95);
+      padding:18px 24px;
+      border-radius:8px;
+      box-shadow:0 2px 12px rgba(0,0,0,0.12);
+      max-width:340px;
+      font-family: "Segoe UI", sans-serif;
+    }
+
+    .panel-section {
+      margin-bottom:14px;
+    }
+
+    .small-text {
+      font-size:11px;
+      color:#4a4a4a;
+    }
+
+    #authPanel form {
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      margin-bottom:8px;
+      font-size:12px;
+    }
+
+    #authPanel input {
+      padding:6px 8px;
+      border:1px solid #ccc;
+      border-radius:4px;
+      box-sizing:border-box;
+      font-size:12px;
+    }
+
+    #authPanel button {
+      padding:6px 10px;
+      border:none;
+      border-radius:4px;
+      cursor:pointer;
+      font-size:12px;
+    }
+
+    #loginForm button {
+      background:#28a745;
+      color:#fff;
+    }
+
+    #registerForm button {
+      background:#17a2b8;
+      color:#fff;
+    }
+
+    #logoutButton {
+      background:#6c757d;
+      color:#fff;
+      display:none;
+    }
+
+    #registerDetails {
+      margin-bottom:8px;
+    }
+
+    #registerDetails summary {
+      cursor:pointer;
+      font-weight:600;
+      margin-bottom:6px;
+    }
+
+    #historyPanel {
+      max-height:200px;
+      overflow-y:auto;
+      background:rgba(248,249,250,0.7);
+      border-radius:6px;
+      padding:8px;
+    }
+
+    #historyPanel ul {
+      list-style:none;
+      margin:0;
+      padding:0;
+    }
+
+    #historyPanel li {
+      border-bottom:1px solid rgba(0,0,0,0.08);
+      padding:6px 0;
+      font-size:12px;
+    }
+
+    #historyPanel li:last-child {
+      border-bottom:none;
+    }
   </style>
 </head>
 <body>
-  <div style="position:absolute;top:10px;right:10px;z-index:2000;background:rgba(255,255,255,0.95);padding:18px 24px;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,0.12);max-width:320px;">
-    <div id="status" style="margin-bottom:10px;font-weight:bold;font-size:12px;">Connecting...</div>
-    <form id="impactForm">
+  <div id="controlPanel">
+    <div id="status" class="panel-section" style="margin-bottom:10px;font-weight:bold;font-size:12px;">Connecting...</div>
+    <div id="authPanel" class="panel-section">
+      <div id="authStatusText" class="small-text" style="font-size:12px;font-weight:600;">Not signed in</div>
+      <form id="loginForm">
+        <input type="text" id="login_username" name="login_username" placeholder="Username" required>
+        <input type="password" id="login_password" name="login_password" placeholder="Password" required>
+        <button type="submit">Sign In</button>
+      </form>
+      <details id="registerDetails">
+        <summary class="small-text">Create an account</summary>
+        <form id="registerForm">
+          <input type="text" id="register_username" name="register_username" placeholder="Username" required>
+          <input type="email" id="register_email" name="register_email" placeholder="Email" required>
+          <input type="text" id="register_full_name" name="register_full_name" placeholder="Full Name (optional)">
+          <input type="password" id="register_password" name="register_password" placeholder="Password" required>
+          <button type="submit">Sign Up</button>
+        </form>
+      </details>
+      <button id="logoutButton" type="button">Sign Out</button>
+      <div id="authFeedback" class="small-text" style="margin-top:6px;"></div>
+    </div>
+    <div id="historyPanel" class="panel-section">
+      <h4 style="margin:0 0 6px 0;font-size:13px;">Recent Simulations</h4>
+      <div id="historyContent" class="small-text">Sign in to view your recent runs.</div>
+    </div>
+    <form id="impactForm" class="panel-section">
       <h3 style="margin-top:0">Asteroid Impact Settings</h3>
   <label for="latitude">Latitude:</label>
   <input type="number" id="latitude" name="latitude" step="0.01" value="33.8938" style="width:80px;margin-bottom:8px"><br>
@@ -104,38 +224,207 @@
     import { setupCesiumVisualization } from './cesium-visualization.js';
     import { MeteorMadnessAPI } from './api-client.js';
     
-    // Store user input and pass to Cesium visualization
-    let userImpactSettings = {
-      latitude: 30.0,
-      longitude: 10.0,
-      elevation: 0.0,
-      crater_diameter: 1200,
-      blast_radius: 50000,
-      thermal_radius: 80000,
-      fireball_radius: 20000,
-      evacuation_radius: 100000
-    };
+    const impactForm = document.getElementById('impactForm');
+    const statusElement = document.getElementById('status');
+    const authStatus = document.getElementById('authStatusText');
+    const authFeedback = document.getElementById('authFeedback');
+    const loginForm = document.getElementById('loginForm');
+    const registerForm = document.getElementById('registerForm');
+    const logoutButton = document.getElementById('logoutButton');
+    const registerDetails = document.getElementById('registerDetails');
+    const historyContent = document.getElementById('historyContent');
 
-    // Initialize API client
+    const numericFields = [
+      'latitude', 'longitude', 'elevation', 'crater_diameter', 'blast_radius',
+      'thermal_radius', 'fireball_radius', 'evacuation_radius', 'asteroid_size',
+      'asteroid_speed', 'asteroid_mass', 'asteroid_density', 'launch_latitude',
+      'launch_longitude', 'launch_altitude'
+    ];
+
+    function readImpactForm() {
+      const values = {};
+      numericFields.forEach((field) => {
+        const input = document.getElementById(field);
+        if (input) {
+          const parsed = parseFloat(input.value);
+          values[field] = Number.isNaN(parsed) ? 0 : parsed;
+        }
+      });
+      return values;
+    }
+
+    function updateImpactFormFromSettings(settings) {
+      numericFields.forEach((field) => {
+        if (settings[field] !== undefined && !Number.isNaN(settings[field])) {
+          const input = document.getElementById(field);
+          if (input) {
+            input.value = settings[field];
+          }
+        }
+      });
+    }
+
+    let userImpactSettings = readImpactForm();
+
+    function setImpactSettings(nextSettings) {
+      userImpactSettings = { ...userImpactSettings, ...nextSettings };
+    }
+
+    window.getImpactSettings = () => ({ ...userImpactSettings });
+
+    impactForm.addEventListener('input', () => {
+      setImpactSettings(readImpactForm());
+    });
+
     const api = new MeteorMadnessAPI();
 
-    // Check backend connection on page load
+    const authState = {
+      profile: null,
+    };
+
+    function setAuthFeedback(message, type = 'info') {
+      authFeedback.textContent = message || '';
+      if (!message) {
+        return;
+      }
+
+      const colors = {
+        info: '#4a4a4a',
+        error: '#dc3545',
+        success: '#28a745'
+      };
+      authFeedback.style.color = colors[type] || colors.info;
+    }
+
+    function updateAuthUI() {
+      if (authState.profile) {
+        authStatus.textContent = `Signed in as ${authState.profile.username}`;
+        authStatus.style.color = '#155724';
+        loginForm.style.display = 'none';
+        registerDetails.style.display = 'none';
+        logoutButton.style.display = 'block';
+        registerDetails.open = false;
+      } else {
+        authStatus.textContent = 'Not signed in';
+        authStatus.style.color = '#4a4a4a';
+        loginForm.style.display = 'flex';
+        registerDetails.style.display = 'block';
+        logoutButton.style.display = 'none';
+      }
+    }
+
+    async function refreshSimulationHistory() {
+      if (!historyContent) {
+        return;
+      }
+
+      if (!api._getAuthToken()) {
+        historyContent.textContent = 'Sign in to view your recent runs.';
+        return;
+      }
+
+      historyContent.textContent = 'Loading history...';
+      try {
+        const history = await api.getSimulationHistory({ limit: 5 });
+        if (!history.simulations || history.simulations.length === 0) {
+          historyContent.textContent = 'No saved simulations yet. Run one to see it here.';
+          return;
+        }
+
+        const list = document.createElement('ul');
+        history.simulations.forEach((sim) => {
+          const item = document.createElement('li');
+          const createdAt = new Date(sim.created_at).toLocaleString();
+          const crater = Math.round(sim.impact_result.crater_diameter).toLocaleString();
+          const blastKm = (sim.impact_result.blast_radius / 1000).toFixed(1);
+          item.innerHTML = `<strong>${createdAt}</strong><br><span>Crater: ${crater} m • Blast: ${blastKm} km</span>`;
+          list.appendChild(item);
+        });
+
+        historyContent.innerHTML = '';
+        historyContent.appendChild(list);
+      } catch (error) {
+        console.error('Failed to load history:', error);
+        historyContent.textContent = error.message || 'Unable to load history.';
+      }
+    }
+
+    async function bootstrapAuth() {
+      if (api._getAuthToken()) {
+        try {
+          authState.profile = await api.getProfile();
+          setAuthFeedback(`Welcome back, ${authState.profile.username}!`, 'success');
+        } catch (error) {
+          console.warn('Unable to restore session:', error);
+          authState.profile = null;
+          setAuthFeedback('Session expired. Please sign in again.', 'error');
+        }
+      }
+      updateAuthUI();
+      await refreshSimulationHistory();
+    }
+
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(loginForm);
+      setAuthFeedback('Signing in...', 'info');
+      try {
+        await api.loginUser({
+          username: formData.get('login_username'),
+          password: formData.get('login_password')
+        });
+        authState.profile = await api.getProfile();
+        setAuthFeedback(`Signed in as ${authState.profile.username}`, 'success');
+        loginForm.reset();
+        updateAuthUI();
+        await refreshSimulationHistory();
+      } catch (error) {
+        setAuthFeedback(error.message || 'Login failed', 'error');
+      }
+    });
+
+    registerForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(registerForm);
+      setAuthFeedback('Creating account...', 'info');
+      try {
+        await api.registerUser({
+          username: formData.get('register_username'),
+          email: formData.get('register_email'),
+          full_name: formData.get('register_full_name') || undefined,
+          password: formData.get('register_password')
+        });
+        setAuthFeedback('Account created! Please sign in.', 'success');
+        registerForm.reset();
+      } catch (error) {
+        setAuthFeedback(error.message || 'Registration failed', 'error');
+      }
+    });
+
+    logoutButton.addEventListener('click', async () => {
+      api.clearStoredTokens();
+      authState.profile = null;
+      setAuthFeedback('Signed out.', 'info');
+      updateAuthUI();
+      await refreshSimulationHistory();
+    });
+
     async function checkBackendConnection() {
       try {
         const version = await api.getVersion();
         console.log('Backend connected:', version);
-        document.getElementById('status').textContent = `Backend Connected (v${version.version})`;
-        document.getElementById('status').style.color = 'green';
+        statusElement.textContent = `Backend Connected (v${version.version})`;
+        statusElement.style.color = 'green';
       } catch (error) {
         console.error('Backend connection failed:', error);
-        document.getElementById('status').textContent = 'Backend Disconnected';
-        document.getElementById('status').style.color = 'red';
+        statusElement.textContent = 'Backend Disconnected';
+        statusElement.style.color = 'red';
       }
     }
 
-    document.getElementById('impactForm').addEventListener('submit', async function(e) {
+    impactForm.addEventListener('submit', async function(e) {
       e.preventDefault();
-      
+
       // Show loading state
       const submitButton = e.target.querySelector('button[type="submit"]');
       const originalText = submitButton.textContent;
@@ -143,24 +432,7 @@
       submitButton.disabled = true;
 
       try {
-        // Collect form data
-        const formData = {
-          latitude: parseFloat(document.getElementById('latitude').value),
-          longitude: parseFloat(document.getElementById('longitude').value),
-          elevation: parseFloat(document.getElementById('elevation').value),
-          crater_diameter: parseFloat(document.getElementById('crater_diameter').value),
-          blast_radius: parseFloat(document.getElementById('blast_radius').value),
-          thermal_radius: parseFloat(document.getElementById('thermal_radius').value),
-          fireball_radius: parseFloat(document.getElementById('fireball_radius').value),
-          evacuation_radius: parseFloat(document.getElementById('evacuation_radius').value),
-          asteroid_size: parseFloat(document.getElementById('asteroid_size').value),
-          asteroid_speed: parseFloat(document.getElementById('asteroid_speed').value),
-          asteroid_mass: parseFloat(document.getElementById('asteroid_mass').value),
-          asteroid_density: parseFloat(document.getElementById('asteroid_density').value),
-          launch_latitude: parseFloat(document.getElementById('launch_latitude').value),
-          launch_longitude: parseFloat(document.getElementById('launch_longitude').value),
-          launch_altitude: parseFloat(document.getElementById('launch_altitude').value)
-        };
+        const formData = readImpactForm();
 
         // Call backend simulation API
         const simulationResult = await api.simulateImpact(
@@ -177,14 +449,16 @@
           },
           {
             useNasaData: true,
-            useML: true
+            useML: true,
+            calculateTrajectory: true,
+            includeZones: true
           }
         );
 
         console.log('Simulation result:', simulationResult);
 
         // Update user settings with backend results
-        userImpactSettings = {
+        setImpactSettings({
           ...formData,
           // Use backend calculated values if available
           crater_diameter: simulationResult.impact_result?.crater_diameter || formData.crater_diameter,
@@ -192,48 +466,37 @@
           thermal_radius: simulationResult.impact_result?.thermal_radius || formData.thermal_radius,
           fireball_radius: simulationResult.impact_result?.fireball_radius || formData.fireball_radius,
           evacuation_radius: simulationResult.impact_result?.evacuation_radius || formData.evacuation_radius
-        };
+        });
 
         // Update form with backend results
         if (simulationResult.impact_result) {
-          document.getElementById('crater_diameter').value = simulationResult.impact_result.crater_diameter;
-          document.getElementById('blast_radius').value = simulationResult.impact_result.blast_radius;
-          document.getElementById('thermal_radius').value = simulationResult.impact_result.thermal_radius;
-          document.getElementById('fireball_radius').value = simulationResult.impact_result.fireball_radius;
-          document.getElementById('evacuation_radius').value = simulationResult.impact_result.evacuation_radius;
+          updateImpactFormFromSettings({
+            crater_diameter: simulationResult.impact_result.crater_diameter,
+            blast_radius: simulationResult.impact_result.blast_radius,
+            thermal_radius: simulationResult.impact_result.thermal_radius,
+            fireball_radius: simulationResult.impact_result.fireball_radius,
+            evacuation_radius: simulationResult.impact_result.evacuation_radius
+          });
+          setImpactSettings(readImpactForm());
         }
 
         // Trigger visualization update
-        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: userImpactSettings }));
+        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: { ...userImpactSettings } }));
 
         // Show success message
-        document.getElementById('status').textContent = 'Simulation Complete!';
-        document.getElementById('status').style.color = 'green';
+        statusElement.textContent = 'Simulation Complete!';
+        statusElement.style.color = 'green';
+
+        await refreshSimulationHistory();
 
       } catch (error) {
         console.error('Simulation failed:', error);
-        document.getElementById('status').textContent = 'Simulation Failed';
-        document.getElementById('status').style.color = 'red';
-        
+        statusElement.textContent = 'Simulation Failed';
+        statusElement.style.color = 'red';
+
         // Fallback to local simulation
-        userImpactSettings = {
-          latitude: parseFloat(document.getElementById('latitude').value),
-          longitude: parseFloat(document.getElementById('longitude').value),
-          elevation: parseFloat(document.getElementById('elevation').value),
-          crater_diameter: parseFloat(document.getElementById('crater_diameter').value),
-          blast_radius: parseFloat(document.getElementById('blast_radius').value),
-          thermal_radius: parseFloat(document.getElementById('thermal_radius').value),
-          fireball_radius: parseFloat(document.getElementById('fireball_radius').value),
-          evacuation_radius: parseFloat(document.getElementById('evacuation_radius').value),
-          asteroid_size: parseFloat(document.getElementById('asteroid_size').value),
-          asteroid_speed: parseFloat(document.getElementById('asteroid_speed').value),
-          asteroid_mass: parseFloat(document.getElementById('asteroid_mass').value),
-          asteroid_density: parseFloat(document.getElementById('asteroid_density').value),
-          launch_latitude: parseFloat(document.getElementById('launch_latitude').value),
-          launch_longitude: parseFloat(document.getElementById('launch_longitude').value),
-          launch_altitude: parseFloat(document.getElementById('launch_altitude').value)
-        };
-        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: userImpactSettings }));
+        setImpactSettings(readImpactForm());
+        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: { ...userImpactSettings } }));
       } finally {
         // Reset button state
         submitButton.textContent = originalText;
@@ -241,10 +504,9 @@
       }
     });
 
-    window.getImpactSettings = () => userImpactSettings;
-    
     // Initialize
     checkBackendConnection();
+    bootstrapAuth();
     setupCesiumVisualization('cesiumContainer');
   </script>
 </body>

--- a/astroyd-meteor-madness-main/cesium-visualization.js
+++ b/astroyd-meteor-madness-main/cesium-visualization.js
@@ -11,7 +11,7 @@ export function setupCesiumVisualization(containerId) {
 }
 
 function runCesium(containerId) {
-  Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyNDMzMTYwMy1hNDI2LTQ0NjAtOGM5MC02OGNhOGIwOGM0ODEiLCJpZCI6MzM4MzI2LCJpYXQiOjE3NTY5ODE5MDl9.MziOOEJHn4bXXuOm-RkxvZ8fD9YgqkOGyfbflKkxjaY';
+  Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI2ODM4NDkyMC04ZDc1LTRkNmYtYjRlNi1hN2YyYTkzYzI1OWIiLCJpZCI6MzM4MzI2LCJpYXQiOjE3NTk1ODMyODN9.8Oh3jFNzuWbGuNUYmt6VewXvFwKuqQwrWoeCw1VfVi8';
   const viewer = new Cesium.Viewer(containerId, {
     terrain: Cesium.Terrain.fromWorldTerrain(),
   });
@@ -46,27 +46,12 @@ function runCesium(containerId) {
   );
 
   // Listen for user input changes
-  window.addEventListener('impactSettingsChanged', (e) => {
-    impact_location = { ...e.detail };
-    impact_result = {
-      blast_radius: impact_location.blast_radius,
-      crater_diameter: impact_location.crater_diameter,
-      thermal_radius: impact_location.thermal_radius,
-      fireball_radius: impact_location.fireball_radius,
-      evacuation_radius: impact_location.evacuation_radius
-    };
-    asteroid_properties = {
-      size: impact_location.asteroid_size || 50,
-      speed: impact_location.asteroid_speed || 20000,
-      mass: impact_location.asteroid_mass || 1000000,
-      density: impact_location.asteroid_density || 3000
-    };
-    impactCartesian = Cesium.Cartesian3.fromDegrees(
-      impact_location.longitude,
-      impact_location.latitude,
-      impact_location.elevation
-    );
-    resetSimulation();
+  window.addEventListener('impactSettingsChanged', (event) => {
+    if (!event || typeof event.detail !== 'object') {
+      resetSimulation();
+      return;
+    }
+    resetSimulation(event.detail);
   });
 
   // Animation cleanup function
@@ -420,7 +405,7 @@ function runCesium(containerId) {
       });
     }
   });
-  function resetSimulation() {
+  function resetSimulation(nextSettings = null) {
     viewer.entities.removeAll();
     state.visualizationEntities.clear();
     state.craterEntities.clear();
@@ -428,13 +413,22 @@ function runCesium(containerId) {
     document.getElementById('toggleButton').style.display = 'none';
     document.getElementById('toggleButton').textContent = 'Show Crater';
     // Always use latest user input
-    impact_location = { ...window.getImpactSettings() };
+    const latestSettings = nextSettings && typeof nextSettings === 'object'
+      ? nextSettings
+      : window.getImpactSettings();
+    impact_location = { ...latestSettings };
     impact_result = {
       blast_radius: impact_location.blast_radius,
       crater_diameter: impact_location.crater_diameter,
       thermal_radius: impact_location.thermal_radius,
       fireball_radius: impact_location.fireball_radius,
       evacuation_radius: impact_location.evacuation_radius
+    };
+    asteroid_properties = {
+      size: impact_location.asteroid_size || 50,
+      speed: impact_location.asteroid_speed || 20000,
+      mass: impact_location.asteroid_mass || 1000000,
+      density: impact_location.asteroid_density || 3000
     };
     impactCartesian = Cesium.Cartesian3.fromDegrees(
       impact_location.longitude,
@@ -456,7 +450,10 @@ function runCesium(containerId) {
       }
     });
   }
-  document.getElementById('launchButton').addEventListener('click', resetSimulation);
+  const launchButton = document.getElementById('launchButton');
+  if (launchButton) {
+    launchButton.addEventListener('click', resetSimulation);
+  }
   // Initial setup
   // resetSimulation(); // Remove this line so asteroid only launches on button click
 }

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -55,12 +55,132 @@
     #cameraToggleButton:hover {
       background: rgba(0, 153, 255, 0.8);
     }
+
+    #controlPanel {
+      position:absolute;
+      top:10px;
+      right:10px;
+      z-index:2000;
+      background:rgba(255,255,255,0.95);
+      padding:18px 24px;
+      border-radius:8px;
+      box-shadow:0 2px 12px rgba(0,0,0,0.12);
+      max-width:340px;
+      font-family: "Segoe UI", sans-serif;
+    }
+
+    .panel-section {
+      margin-bottom:14px;
+    }
+
+    .small-text {
+      font-size:11px;
+      color:#4a4a4a;
+    }
+
+    #authPanel form {
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      margin-bottom:8px;
+      font-size:12px;
+    }
+
+    #authPanel input {
+      padding:6px 8px;
+      border:1px solid #ccc;
+      border-radius:4px;
+      box-sizing:border-box;
+      font-size:12px;
+    }
+
+    #authPanel button {
+      padding:6px 10px;
+      border:none;
+      border-radius:4px;
+      cursor:pointer;
+      font-size:12px;
+    }
+
+    #loginForm button {
+      background:#28a745;
+      color:#fff;
+    }
+
+    #registerForm button {
+      background:#17a2b8;
+      color:#fff;
+    }
+
+    #logoutButton {
+      background:#6c757d;
+      color:#fff;
+      display:none;
+    }
+
+    #registerDetails {
+      margin-bottom:8px;
+    }
+
+    #registerDetails summary {
+      cursor:pointer;
+      font-weight:600;
+      margin-bottom:6px;
+    }
+
+    #historyPanel {
+      max-height:200px;
+      overflow-y:auto;
+      background:rgba(248,249,250,0.7);
+      border-radius:6px;
+      padding:8px;
+    }
+
+    #historyPanel ul {
+      list-style:none;
+      margin:0;
+      padding:0;
+    }
+
+    #historyPanel li {
+      border-bottom:1px solid rgba(0,0,0,0.08);
+      padding:6px 0;
+      font-size:12px;
+    }
+
+    #historyPanel li:last-child {
+      border-bottom:none;
+    }
   </style>
 </head>
 <body>
-  <div style="position:absolute;top:10px;right:10px;z-index:2000;background:rgba(255,255,255,0.95);padding:18px 24px;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,0.12);max-width:320px;">
-    <div id="status" style="margin-bottom:10px;font-weight:bold;font-size:12px;">Connecting...</div>
-    <form id="impactForm">
+  <div id="controlPanel">
+    <div id="status" class="panel-section" style="margin-bottom:10px;font-weight:bold;font-size:12px;">Connecting...</div>
+    <div id="authPanel" class="panel-section">
+      <div id="authStatusText" class="small-text" style="font-size:12px;font-weight:600;">Not signed in</div>
+      <form id="loginForm">
+        <input type="text" id="login_username" name="login_username" placeholder="Username" required>
+        <input type="password" id="login_password" name="login_password" placeholder="Password" required>
+        <button type="submit">Sign In</button>
+      </form>
+      <details id="registerDetails">
+        <summary class="small-text">Create an account</summary>
+        <form id="registerForm">
+          <input type="text" id="register_username" name="register_username" placeholder="Username" required>
+          <input type="email" id="register_email" name="register_email" placeholder="Email" required>
+          <input type="text" id="register_full_name" name="register_full_name" placeholder="Full Name (optional)">
+          <input type="password" id="register_password" name="register_password" placeholder="Password" required>
+          <button type="submit">Sign Up</button>
+        </form>
+      </details>
+      <button id="logoutButton" type="button">Sign Out</button>
+      <div id="authFeedback" class="small-text" style="margin-top:6px;"></div>
+    </div>
+    <div id="historyPanel" class="panel-section">
+      <h4 style="margin:0 0 6px 0;font-size:13px;">Recent Simulations</h4>
+      <div id="historyContent" class="small-text">Sign in to view your recent runs.</div>
+    </div>
+    <form id="impactForm" class="panel-section">
       <h3 style="margin-top:0">Asteroid Impact Settings</h3>
   <label for="latitude">Latitude:</label>
   <input type="number" id="latitude" name="latitude" step="0.01" value="33.8938" style="width:80px;margin-bottom:8px"><br>
@@ -104,38 +224,207 @@
     import { setupCesiumVisualization } from './cesium-visualization.js';
     import { MeteorMadnessAPI } from './api-client.js';
     
-    // Store user input and pass to Cesium visualization
-    let userImpactSettings = {
-      latitude: 30.0,
-      longitude: 10.0,
-      elevation: 0.0,
-      crater_diameter: 1200,
-      blast_radius: 50000,
-      thermal_radius: 80000,
-      fireball_radius: 20000,
-      evacuation_radius: 100000
-    };
+    const impactForm = document.getElementById('impactForm');
+    const statusElement = document.getElementById('status');
+    const authStatus = document.getElementById('authStatusText');
+    const authFeedback = document.getElementById('authFeedback');
+    const loginForm = document.getElementById('loginForm');
+    const registerForm = document.getElementById('registerForm');
+    const logoutButton = document.getElementById('logoutButton');
+    const registerDetails = document.getElementById('registerDetails');
+    const historyContent = document.getElementById('historyContent');
 
-    // Initialize API client
+    const numericFields = [
+      'latitude', 'longitude', 'elevation', 'crater_diameter', 'blast_radius',
+      'thermal_radius', 'fireball_radius', 'evacuation_radius', 'asteroid_size',
+      'asteroid_speed', 'asteroid_mass', 'asteroid_density', 'launch_latitude',
+      'launch_longitude', 'launch_altitude'
+    ];
+
+    function readImpactForm() {
+      const values = {};
+      numericFields.forEach((field) => {
+        const input = document.getElementById(field);
+        if (input) {
+          const parsed = parseFloat(input.value);
+          values[field] = Number.isNaN(parsed) ? 0 : parsed;
+        }
+      });
+      return values;
+    }
+
+    function updateImpactFormFromSettings(settings) {
+      numericFields.forEach((field) => {
+        if (settings[field] !== undefined && !Number.isNaN(settings[field])) {
+          const input = document.getElementById(field);
+          if (input) {
+            input.value = settings[field];
+          }
+        }
+      });
+    }
+
+    let userImpactSettings = readImpactForm();
+
+    function setImpactSettings(nextSettings) {
+      userImpactSettings = { ...userImpactSettings, ...nextSettings };
+    }
+
+    window.getImpactSettings = () => ({ ...userImpactSettings });
+
+    impactForm.addEventListener('input', () => {
+      setImpactSettings(readImpactForm());
+    });
+
     const api = new MeteorMadnessAPI();
 
-    // Check backend connection on page load
+    const authState = {
+      profile: null,
+    };
+
+    function setAuthFeedback(message, type = 'info') {
+      authFeedback.textContent = message || '';
+      if (!message) {
+        return;
+      }
+
+      const colors = {
+        info: '#4a4a4a',
+        error: '#dc3545',
+        success: '#28a745'
+      };
+      authFeedback.style.color = colors[type] || colors.info;
+    }
+
+    function updateAuthUI() {
+      if (authState.profile) {
+        authStatus.textContent = `Signed in as ${authState.profile.username}`;
+        authStatus.style.color = '#155724';
+        loginForm.style.display = 'none';
+        registerDetails.style.display = 'none';
+        logoutButton.style.display = 'block';
+        registerDetails.open = false;
+      } else {
+        authStatus.textContent = 'Not signed in';
+        authStatus.style.color = '#4a4a4a';
+        loginForm.style.display = 'flex';
+        registerDetails.style.display = 'block';
+        logoutButton.style.display = 'none';
+      }
+    }
+
+    async function refreshSimulationHistory() {
+      if (!historyContent) {
+        return;
+      }
+
+      if (!api._getAuthToken()) {
+        historyContent.textContent = 'Sign in to view your recent runs.';
+        return;
+      }
+
+      historyContent.textContent = 'Loading history...';
+      try {
+        const history = await api.getSimulationHistory({ limit: 5 });
+        if (!history.simulations || history.simulations.length === 0) {
+          historyContent.textContent = 'No saved simulations yet. Run one to see it here.';
+          return;
+        }
+
+        const list = document.createElement('ul');
+        history.simulations.forEach((sim) => {
+          const item = document.createElement('li');
+          const createdAt = new Date(sim.created_at).toLocaleString();
+          const crater = Math.round(sim.impact_result.crater_diameter).toLocaleString();
+          const blastKm = (sim.impact_result.blast_radius / 1000).toFixed(1);
+          item.innerHTML = `<strong>${createdAt}</strong><br><span>Crater: ${crater} m • Blast: ${blastKm} km</span>`;
+          list.appendChild(item);
+        });
+
+        historyContent.innerHTML = '';
+        historyContent.appendChild(list);
+      } catch (error) {
+        console.error('Failed to load history:', error);
+        historyContent.textContent = error.message || 'Unable to load history.';
+      }
+    }
+
+    async function bootstrapAuth() {
+      if (api._getAuthToken()) {
+        try {
+          authState.profile = await api.getProfile();
+          setAuthFeedback(`Welcome back, ${authState.profile.username}!`, 'success');
+        } catch (error) {
+          console.warn('Unable to restore session:', error);
+          authState.profile = null;
+          setAuthFeedback('Session expired. Please sign in again.', 'error');
+        }
+      }
+      updateAuthUI();
+      await refreshSimulationHistory();
+    }
+
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(loginForm);
+      setAuthFeedback('Signing in...', 'info');
+      try {
+        await api.loginUser({
+          username: formData.get('login_username'),
+          password: formData.get('login_password')
+        });
+        authState.profile = await api.getProfile();
+        setAuthFeedback(`Signed in as ${authState.profile.username}`, 'success');
+        loginForm.reset();
+        updateAuthUI();
+        await refreshSimulationHistory();
+      } catch (error) {
+        setAuthFeedback(error.message || 'Login failed', 'error');
+      }
+    });
+
+    registerForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(registerForm);
+      setAuthFeedback('Creating account...', 'info');
+      try {
+        await api.registerUser({
+          username: formData.get('register_username'),
+          email: formData.get('register_email'),
+          full_name: formData.get('register_full_name') || undefined,
+          password: formData.get('register_password')
+        });
+        setAuthFeedback('Account created! Please sign in.', 'success');
+        registerForm.reset();
+      } catch (error) {
+        setAuthFeedback(error.message || 'Registration failed', 'error');
+      }
+    });
+
+    logoutButton.addEventListener('click', async () => {
+      api.clearStoredTokens();
+      authState.profile = null;
+      setAuthFeedback('Signed out.', 'info');
+      updateAuthUI();
+      await refreshSimulationHistory();
+    });
+
     async function checkBackendConnection() {
       try {
         const version = await api.getVersion();
         console.log('Backend connected:', version);
-        document.getElementById('status').textContent = `Backend Connected (v${version.version})`;
-        document.getElementById('status').style.color = 'green';
+        statusElement.textContent = `Backend Connected (v${version.version})`;
+        statusElement.style.color = 'green';
       } catch (error) {
         console.error('Backend connection failed:', error);
-        document.getElementById('status').textContent = 'Backend Disconnected';
-        document.getElementById('status').style.color = 'red';
+        statusElement.textContent = 'Backend Disconnected';
+        statusElement.style.color = 'red';
       }
     }
 
-    document.getElementById('impactForm').addEventListener('submit', async function(e) {
+    impactForm.addEventListener('submit', async function(e) {
       e.preventDefault();
-      
+
       // Show loading state
       const submitButton = e.target.querySelector('button[type="submit"]');
       const originalText = submitButton.textContent;
@@ -143,24 +432,7 @@
       submitButton.disabled = true;
 
       try {
-        // Collect form data
-        const formData = {
-          latitude: parseFloat(document.getElementById('latitude').value),
-          longitude: parseFloat(document.getElementById('longitude').value),
-          elevation: parseFloat(document.getElementById('elevation').value),
-          crater_diameter: parseFloat(document.getElementById('crater_diameter').value),
-          blast_radius: parseFloat(document.getElementById('blast_radius').value),
-          thermal_radius: parseFloat(document.getElementById('thermal_radius').value),
-          fireball_radius: parseFloat(document.getElementById('fireball_radius').value),
-          evacuation_radius: parseFloat(document.getElementById('evacuation_radius').value),
-          asteroid_size: parseFloat(document.getElementById('asteroid_size').value),
-          asteroid_speed: parseFloat(document.getElementById('asteroid_speed').value),
-          asteroid_mass: parseFloat(document.getElementById('asteroid_mass').value),
-          asteroid_density: parseFloat(document.getElementById('asteroid_density').value),
-          launch_latitude: parseFloat(document.getElementById('launch_latitude').value),
-          launch_longitude: parseFloat(document.getElementById('launch_longitude').value),
-          launch_altitude: parseFloat(document.getElementById('launch_altitude').value)
-        };
+        const formData = readImpactForm();
 
         // Call backend simulation API
         const simulationResult = await api.simulateImpact(
@@ -177,14 +449,16 @@
           },
           {
             useNasaData: true,
-            useML: true
+            useML: true,
+            calculateTrajectory: true,
+            includeZones: true
           }
         );
 
         console.log('Simulation result:', simulationResult);
 
         // Update user settings with backend results
-        userImpactSettings = {
+        setImpactSettings({
           ...formData,
           // Use backend calculated values if available
           crater_diameter: simulationResult.impact_result?.crater_diameter || formData.crater_diameter,
@@ -192,48 +466,37 @@
           thermal_radius: simulationResult.impact_result?.thermal_radius || formData.thermal_radius,
           fireball_radius: simulationResult.impact_result?.fireball_radius || formData.fireball_radius,
           evacuation_radius: simulationResult.impact_result?.evacuation_radius || formData.evacuation_radius
-        };
+        });
 
         // Update form with backend results
         if (simulationResult.impact_result) {
-          document.getElementById('crater_diameter').value = simulationResult.impact_result.crater_diameter;
-          document.getElementById('blast_radius').value = simulationResult.impact_result.blast_radius;
-          document.getElementById('thermal_radius').value = simulationResult.impact_result.thermal_radius;
-          document.getElementById('fireball_radius').value = simulationResult.impact_result.fireball_radius;
-          document.getElementById('evacuation_radius').value = simulationResult.impact_result.evacuation_radius;
+          updateImpactFormFromSettings({
+            crater_diameter: simulationResult.impact_result.crater_diameter,
+            blast_radius: simulationResult.impact_result.blast_radius,
+            thermal_radius: simulationResult.impact_result.thermal_radius,
+            fireball_radius: simulationResult.impact_result.fireball_radius,
+            evacuation_radius: simulationResult.impact_result.evacuation_radius
+          });
+          setImpactSettings(readImpactForm());
         }
 
         // Trigger visualization update
-        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: userImpactSettings }));
+        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: { ...userImpactSettings } }));
 
         // Show success message
-        document.getElementById('status').textContent = 'Simulation Complete!';
-        document.getElementById('status').style.color = 'green';
+        statusElement.textContent = 'Simulation Complete!';
+        statusElement.style.color = 'green';
+
+        await refreshSimulationHistory();
 
       } catch (error) {
         console.error('Simulation failed:', error);
-        document.getElementById('status').textContent = 'Simulation Failed';
-        document.getElementById('status').style.color = 'red';
-        
+        statusElement.textContent = 'Simulation Failed';
+        statusElement.style.color = 'red';
+
         // Fallback to local simulation
-        userImpactSettings = {
-          latitude: parseFloat(document.getElementById('latitude').value),
-          longitude: parseFloat(document.getElementById('longitude').value),
-          elevation: parseFloat(document.getElementById('elevation').value),
-          crater_diameter: parseFloat(document.getElementById('crater_diameter').value),
-          blast_radius: parseFloat(document.getElementById('blast_radius').value),
-          thermal_radius: parseFloat(document.getElementById('thermal_radius').value),
-          fireball_radius: parseFloat(document.getElementById('fireball_radius').value),
-          evacuation_radius: parseFloat(document.getElementById('evacuation_radius').value),
-          asteroid_size: parseFloat(document.getElementById('asteroid_size').value),
-          asteroid_speed: parseFloat(document.getElementById('asteroid_speed').value),
-          asteroid_mass: parseFloat(document.getElementById('asteroid_mass').value),
-          asteroid_density: parseFloat(document.getElementById('asteroid_density').value),
-          launch_latitude: parseFloat(document.getElementById('launch_latitude').value),
-          launch_longitude: parseFloat(document.getElementById('launch_longitude').value),
-          launch_altitude: parseFloat(document.getElementById('launch_altitude').value)
-        };
-        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: userImpactSettings }));
+        setImpactSettings(readImpactForm());
+        window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: { ...userImpactSettings } }));
       } finally {
         // Reset button state
         submitButton.textContent = originalText;
@@ -241,10 +504,9 @@
       }
     });
 
-    window.getImpactSettings = () => userImpactSettings;
-    
     // Initialize
     checkBackendConnection();
+    bootstrapAuth();
     setupCesiumVisualization('cesiumContainer');
   </script>
 </body>


### PR DESCRIPTION
## Summary
- mount the bundled simulator frontend under `/ui` in the main FastAPI app and simplify the standalone static host
- let the browser API client derive the backend URL automatically and document the new access paths
- refresh the Cesium Ion access token used by both bundled visualisation scripts

## Testing
- python - <<'PY'
import sys
from pathlib import Path

repo_root = Path('astroyd-meteor-madness-main').resolve()
sys.path.append(str(repo_root))

from fastapi.testclient import TestClient

from app.frontend import app as frontend_app
from app.main import app as backend_app

frontend_client = TestClient(frontend_app)
resp = frontend_client.get('/')
assert resp.status_code == 200
assert '<!DOCTYPE html>' in resp.text
resp = frontend_client.get('/api-client.js')
assert resp.status_code == 200
assert 'deriveApiBaseUrl' in resp.text

backend_client = TestClient(backend_app)
api_resp = backend_client.get('/api/v1/auth/healthcheck') if backend_app.routes else None
ui_resp = backend_client.get('/ui/')
assert ui_resp.status_code == 200
assert '<!DOCTYPE html>' in ui_resp.text
asset_resp = backend_client.get('/ui/api-client.js')
assert asset_resp.status_code == 200
assert 'deriveApiBaseUrl' in asset_resp.text
print('frontend + backend integration ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e10cba05688322a4b8ae95415c6e77