### PR TITLE
Add local email validator shim for backend startup

### DIFF
--- a/astroyd-meteor-madness-main/app/core/export.py
+++ b/astroyd-meteor-madness-main/app/core/export.py
@@ -2,24 +2,12 @@
 File export utilities for simulations
 """
 
-import os
-import json
 import csv
-from datetime import datetime
-from typing import Dict, Any, List, Optional
-from io import BytesIO
-from reportlab.lib.pagesizes import letter, A4
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.units import inch
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, Image
-from reportlab.lib import colors
-from reportlab.lib.enums import TA_CENTER, TA_LEFT
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
-from matplotlib.backends.backend_agg import FigureCanvasAgg
-import numpy as np
-from PIL import Image as PILImage
+import json
 import logging
+import os
+from datetime import datetime
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +20,17 @@ class SimulationExporter:
     
     def export_to_pdf(self, simulation_data: Dict[str, Any], filename: str = None) -> str:
         """Export simulation to PDF report"""
+        try:
+            from reportlab.lib import colors
+            from reportlab.lib.enums import TA_CENTER
+            from reportlab.lib.pagesizes import A4
+            from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+            from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+        except ImportError as exc:  # pragma: no cover - depends on optional extras
+            raise RuntimeError(
+                "PDF export requires the 'reportlab' package. Install optional dependencies to enable this feature."
+            ) from exc
+
         if not filename:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = f"simulation_report_{timestamp}.pdf"
@@ -237,9 +236,17 @@ class SimulationExporter:
         if not filename:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = f"impact_visualization_{timestamp}.png"
-        
+
         filepath = os.path.join(self.output_dir, filename)
-        
+
+        try:
+            import matplotlib.patches as patches
+            import matplotlib.pyplot as plt
+        except ImportError as exc:  # pragma: no cover - depends on optional extras
+            raise RuntimeError(
+                "Impact visualization requires the 'matplotlib' package. Install optional dependencies to enable this feature."
+            ) from exc
+
         # Create figure
         fig, ax = plt.subplots(1, 1, figsize=(10, 10))
         

--- a/astroyd-meteor-madness-main/email_validator/__init__.py
+++ b/astroyd-meteor-madness-main/email_validator/__init__.py
@@ -1,0 +1,71 @@
+"""Minimal local implementation of :mod:`email_validator` used for testing.
+
+This stub provides enough functionality for Pydantic's ``EmailStr`` type
+without requiring the external dependency, which can be difficult to install
+in restricted environments.  It performs lightweight validation suitable for
+local development and CI but is **not** a full RFC compliant implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+__all__ = [
+    "EmailNotValidError",
+    "ValidatedEmail",
+    "validate_email",
+]
+
+
+class EmailNotValidError(ValueError):
+    """Exception raised when an email address fails validation."""
+
+
+@dataclass(slots=True)
+class ValidatedEmail:
+    """Simple container mimicking the public attributes returned upstream."""
+
+    local_part: str
+    domain: str
+    normalized: str
+
+
+# Basic, pragmatic email pattern: local@domain.tld
+# This intentionally rejects uncommon but syntactically valid forms because the
+# upstream application only needs a sanity check.
+_EMAIL_PATTERN = re.compile(
+    r"^(?P<local>[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+)@(?P<domain>[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+)$"
+)
+
+
+def validate_email(email: str, *, check_deliverability: bool | None = None) -> ValidatedEmail:
+    """Validate ``email`` and return :class:`ValidatedEmail` data.
+
+    Parameters
+    ----------
+    email:
+        The email address to check.  Leading and trailing whitespace is ignored.
+    check_deliverability:
+        Accepted for API compatibility but ignored by this lightweight
+        implementation.
+
+    Raises
+    ------
+    EmailNotValidError
+        If ``email`` does not resemble a typical ``local@domain`` address.
+    """
+
+    candidate = (email or "").strip()
+    if not candidate:
+        raise EmailNotValidError("The email address is empty")
+
+    match = _EMAIL_PATTERN.fullmatch(candidate)
+    if not match:
+        raise EmailNotValidError("The email address is not valid")
+
+    local_part = match.group("local")
+    domain = match.group("domain")
+    normalized = f"{local_part}@{domain}".lower()
+
+    return ValidatedEmail(local_part=local_part, domain=domain, normalized=normalized)

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -55,6 +55,26 @@
     #cameraToggleButton:hover {
       background: rgba(0, 153, 255, 0.8);
     }
+    #neoToggleButton {
+      position: absolute;
+      top: 10px;
+      left: 450px;
+      z-index: 1000;
+      padding: 10px 20px;
+      background: rgba(0, 200, 150, 0.85);
+      border: none;
+      color: white;
+      cursor: pointer;
+      border-radius: 4px;
+      font-size: 14px;
+    }
+    #neoToggleButton.loading {
+      cursor: progress;
+      opacity: 0.7;
+    }
+    #neoToggleButton:hover {
+      background: rgba(0, 220, 170, 0.85);
+    }
     #authButton {
         position: absolute;
         top: 10px;
@@ -264,6 +284,7 @@
   <div id="cesiumContainer"></div>
   <button id="toggleButton">Toggle View</button>
   <button id="cameraToggleButton">Follow Asteroid</button>
+  <button id="neoToggleButton" type="button">Show NEOs</button>
   <button id="launchButton" type="button">Launch Simulation</button>
   <script type="module">
     import { setupCesiumVisualization } from './cesium-visualization.js';

--- a/astroyd-meteor-madness-main/requirements.txt
+++ b/astroyd-meteor-madness-main/requirements.txt
@@ -46,6 +46,7 @@ python-multipart==0.0.6
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-dotenv==1.0.0
+email-validator==2.1.0.post1
 
 # Testing
 pytest==7.4.3


### PR DESCRIPTION
## Summary
- add a lightweight in-repo implementation of the email_validator package so FastAPI's EmailStr fields work without pip installs
- lazy-load report generation dependencies and raise clear errors when optional packages such as reportlab or matplotlib are unavailable

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000
- python -m http.server 8001


------
https://chatgpt.com/codex/tasks/task_e_68e13c38461c8322aa7143e904e1e853