### PR TITLE
feat: add defense planner scenario page

### DIFF
--- a/astroyd-meteor-madness-main/app/api/v1/endpoints/simulation.py
+++ b/astroyd-meteor-madness-main/app/api/v1/endpoints/simulation.py
@@ -548,10 +548,11 @@ async def get_deflection_leaderboard(
                 ties_at_rank += 1
             candidate["rank"] = current_rank
 
+        next_rank = (current_rank + 1) if ranked_candidates else 1
         for entry in leaderboard_entries:
             if entry.get("games_played"):
                 continue
-            entry["rank"] = None
+            entry["rank"] = next_rank
 
         leaderboard_entries.sort(
             key=lambda entry: (

--- a/astroyd-meteor-madness-main/cesium-visualization.js
+++ b/astroyd-meteor-madness-main/cesium-visualization.js
@@ -215,6 +215,19 @@ function runCesium(containerId) {
       createDangerZones();
     });
 
+    window.addEventListener('advancedImpactCalculated', (event) => {
+      const detail = event?.detail;
+      if (detail?.settingsDispatched) {
+        return;
+      }
+      if (detail?.simulation) {
+        applySimulationState(detail.simulation);
+      } else {
+        applySimulationState(window.getImpactSettings ? window.getImpactSettings() : null);
+      }
+      createDangerZones();
+    });
+
     const neoToggleButton = document.getElementById('neoToggleButton');
     const neoListContainer = document.getElementById('neoListContainer');
     const neoList = document.getElementById('neoList');

--- a/astroyd-meteor-madness-main/cesium-visualization.js
+++ b/astroyd-meteor-madness-main/cesium-visualization.js
@@ -185,6 +185,7 @@ function runCesium(containerId) {
     let asteroidEntity = null;
     let pendingDefenseAutoFollow = false;
     let defenseOverlayEnabled = Boolean(window.defenseOverlayEnabled);
+    let latestImpactSelectionId = 0;
 
     const defenseColors = {
       lasers: Cesium.Color.fromCssColorString('#7b1fa2'),
@@ -288,6 +289,8 @@ function runCesium(containerId) {
       if (!cartographic) {
         return;
       }
+      latestImpactSelectionId += 1;
+      const selectionId = latestImpactSelectionId;
       const latitude = Cesium.Math.toDegrees(cartographic.latitude);
       const longitude = Cesium.Math.toDegrees(cartographic.longitude);
       const elevation = cartographic.height ?? 0;
@@ -321,6 +324,10 @@ function runCesium(containerId) {
       if (elevationInput) {
         elevationInput.value = elevation.toFixed(2);
       }
+      const populationDensityInput = document.getElementById('population_density');
+      if (populationDensityInput) {
+        populationDensityInput.value = '';
+      }
       try {
         if (window?.meteorMadnessAPI?.getPopulationDensity) {
           const fetchedDensity = await window.meteorMadnessAPI.getPopulationDensity(latitude, longitude);
@@ -331,13 +338,16 @@ function runCesium(containerId) {
       } catch (error) {
         console.warn('Failed to fetch population density for selected impact location', error);
       }
+       if (selectionId !== latestImpactSelectionId) {
+        return;
+      }
+
 
       impact_location = {
         ...impact_location,
         population_density: populationDensity
       };
 
-      const populationDensityInput = document.getElementById('population_density');
       if (populationDensityInput) {
         populationDensityInput.value = String(Math.round(populationDensity * 100) / 100);
       }

--- a/astroyd-meteor-madness-main/defense-planner.html
+++ b/astroyd-meteor-madness-main/defense-planner.html
@@ -296,17 +296,46 @@
       width: 100%;
       border-collapse: collapse;
       font-size: 0.9rem;
+      background: rgba(10, 15, 25, 0.6);
+      border-radius: 12px;
+      overflow: hidden;
     }
 
     .leaderboard th,
     .leaderboard td {
       padding: 10px 12px;
       text-align: left;
-      border-bottom: 1px solid var(--border);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+      vertical-align: middle;
+    }
+
+    .leaderboard thead {
+      background: rgba(123, 31, 162, 0.18);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.75rem;
     }
 
     .leaderboard tbody tr:nth-child(odd) {
-      background: rgba(15, 23, 42, 0.5);
+      background: rgba(15, 23, 42, 0.45);
+    }
+
+    .leaderboard tbody tr.player-row {
+      background: rgba(123, 31, 162, 0.16);
+      box-shadow: inset 0 0 0 1px rgba(123, 31, 162, 0.32);
+    }
+
+    .leaderboard tbody tr.empty td {
+      text-align: center;
+      color: var(--muted);
+      padding: 18px;
+      font-style: italic;
+    }
+
+    .muted {
+      color: var(--muted);
+      margin: 4px 0 0;
+      font-size: 0.82rem;
     }
 
     footer {
@@ -397,14 +426,17 @@
           <table>
             <thead>
               <tr>
-                <th>Rank</th>
+                <th>#</th>
                 <th>Commander</th>
-                <th>Level</th>
-                <th>Efficiency</th>
+                <th>Score</th>
+                <th>Method</th>
+                <th>Mission</th>
+                <th>Outcome</th>
               </tr>
             </thead>
             <tbody id="leaderboardBody"></tbody>
           </table>
+          <p id="leaderboardStatus" class="muted">Loading live leaderboard…</p>
         </div>
       </div>
     </section>
@@ -423,7 +455,8 @@
         payout: { credits: 3200, research: 6 },
         data: '648m carbonaceous asteroid on a Mars-skimming trajectory redirected toward Earth.',
         baseDamage: 780000,
-        requiredPower: 120
+        requiredPower: 120,
+        impactLocation: { latitude: 15.4, longitude: -74.6, elevation: 0 }
       },
       {
         id: 'aurora-borealis',
@@ -432,7 +465,8 @@
         payout: { credits: 2200, research: 4 },
         data: '392m iron-rich body entering at a polar inclination with high entry speed.',
         baseDamage: 520000,
-        requiredPower: 85
+        requiredPower: 85,
+        impactLocation: { latitude: 69.6, longitude: -96.8, elevation: 0 }
       },
       {
         id: 'pacific-guardian',
@@ -441,7 +475,8 @@
         payout: { credits: 1400, research: 2 },
         data: '190m stony asteroid projected to impact the northern Pacific shipping lanes.',
         baseDamage: 260000,
-        requiredPower: 55
+        requiredPower: 55,
+        impactLocation: { latitude: 24.5, longitude: -151.6, elevation: 0 }
       }
     ];
 
@@ -484,14 +519,18 @@
       }
     ];
 
-    const leaderboard = [
-      { commander: 'Dr. Vega', level: 'Valles Marineris', efficiency: 92 },
-      { commander: 'Commander Imani', level: 'Aurora Borealis', efficiency: 88 },
-      { commander: 'Captain Singh', level: 'Pacific Guardian', efficiency: 81 },
-      { commander: 'Lt. Alvarez', level: 'Aurora Borealis', efficiency: 78 }
+    const API_BASE_URL = window.API_BASE_URL || 'http://localhost:8000/api/v1';
+    const DEFENSE_PLAN_STORAGE_KEY = 'defensePlanner:lastConfiguration';
+
+    const fallbackLeaderboard = [
+      { commander: 'Dr. Vega', mission: 'Valles Marineris', score: 920000, efficiency: 108, method: 'Kinetic Impactor', outcome: 'Success' },
+      { commander: 'Commander Imani', mission: 'Aurora Borealis', score: 880000, efficiency: 102, method: 'Orbital Lasers', outcome: 'Success' },
+      { commander: 'Captain Singh', mission: 'Pacific Guardian', score: 810000, efficiency: 94, method: 'Autonomous Craft', outcome: 'Partial' },
+      { commander: 'Lt. Alvarez', mission: 'Aurora Borealis', score: 780000, efficiency: 90, method: 'Planetary Shields', outcome: 'Success' }
     ];
 
-    let currentLeaderboard = [...leaderboard];
+    const leaderboard = [];
+    let currentLeaderboard = [];
 
     const progressionBase = { credits: 800, research: 1 };
 
@@ -518,9 +557,179 @@
     const costEfficiencyEl = document.getElementById('costEfficiency');
     const leaderboardRankEl = document.getElementById('leaderboardRank');
     const leaderboardBody = document.getElementById('leaderboardBody');
+    const leaderboardStatus = document.getElementById('leaderboardStatus');
 
     function formatCredits(value) {
       return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value * 1000);
+    }
+
+    function formatScore(value) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return '—';
+      }
+      return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+    }
+
+    function mergeOutcomeText(entry) {
+      const parts = [];
+      if (entry?.outcome) {
+        parts.push(entry.outcome);
+      }
+      if (Number.isFinite(entry?.efficiency)) {
+        parts.push(`${entry.efficiency}% eff.`);
+      }
+      return parts.length ? parts.join(' · ') : '—';
+    }
+
+    function getComparableScore(entry) {
+      if (!entry || typeof entry !== 'object') {
+        return 0;
+      }
+      if (Number.isFinite(entry.score)) {
+        return entry.score;
+      }
+      if (Number.isFinite(entry.efficiency)) {
+        return entry.efficiency;
+      }
+      return 0;
+    }
+
+    function transformLeaderboardEntry(entry, index = 0) {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+      const commander = entry.player_name || entry.username || entry.commander || entry.full_name || `Commander ${index + 1}`;
+      const mission = entry.mission || entry.level || entry.level_name || entry.difficulty_level || entry.target || entry.scenario || '—';
+      const method = entry.deflection_method || entry.method || entry.strategy || '—';
+      const rawScore = Number.parseFloat(entry.score);
+      const score = Number.isFinite(rawScore) ? rawScore : null;
+      const efficiencySource = entry.efficiency ?? entry.cost_efficiency ?? entry.success_rate;
+      let efficiency = null;
+      if (Number.isFinite(efficiencySource)) {
+        efficiency = Math.round(efficiencySource * (efficiencySource <= 1 ? 100 : 1));
+      }
+      const outcome = entry.outcome
+        || (typeof entry.success === 'boolean' ? (entry.success ? 'Success' : 'Failed') : null)
+        || (typeof entry.success_rate === 'number' ? `${Math.round(entry.success_rate * 100)}% success` : null);
+
+      return {
+        commander,
+        mission,
+        method,
+        score,
+        efficiency,
+        outcome,
+        raw: entry
+      };
+    }
+
+    function setLeaderboardEntries(entries, { source = 'local', fallbackUsed = false } = {}) {
+      const normalized = entries
+        .filter(Boolean)
+        .map(entry => ({ ...entry }))
+        .sort((a, b) => getComparableScore(b) - getComparableScore(a));
+      leaderboard.length = 0;
+      normalized.forEach(entry => leaderboard.push(entry));
+      currentLeaderboard = [...leaderboard];
+      renderLeaderboard();
+      if (leaderboardStatus) {
+        if (!currentLeaderboard.length) {
+          leaderboardStatus.textContent = 'No leaderboard entries yet. Run a scenario to become the first commander!';
+        } else if (fallbackUsed) {
+          leaderboardStatus.textContent = 'Live leaderboard unavailable — showing recent NASA training sims.';
+        } else if (source === 'api') {
+          leaderboardStatus.textContent = 'Live leaderboard synced with registered commanders.';
+        } else {
+          leaderboardStatus.textContent = 'Leaderboard updated.';
+        }
+      }
+    }
+
+    async function loadLeaderboard() {
+      if (!window.fetch) {
+        setLeaderboardEntries(fallbackLeaderboard, { fallbackUsed: true });
+        return;
+      }
+      try {
+        if (leaderboardStatus) {
+          leaderboardStatus.textContent = 'Loading live leaderboard…';
+        }
+        const response = await fetch(`${API_BASE_URL}/simulation/deflection-game/leaderboard`);
+        if (!response.ok) {
+          throw new Error(`Leaderboard request failed with status ${response.status}`);
+        }
+        const payload = await response.json();
+        const entries = Array.isArray(payload)
+          ? payload
+          : (Array.isArray(payload?.leaderboard) ? payload.leaderboard : []);
+        if (!entries.length) {
+          setLeaderboardEntries([], { source: 'api' });
+          return;
+        }
+        const mapped = entries
+          .map((entry, index) => transformLeaderboardEntry(entry, index))
+          .filter(Boolean);
+        setLeaderboardEntries(mapped, { source: 'api' });
+      } catch (error) {
+        console.warn('Unable to load live leaderboard', error);
+        if (!leaderboard.length) {
+          setLeaderboardEntries(fallbackLeaderboard, { fallbackUsed: true });
+        } else if (leaderboardStatus) {
+          leaderboardStatus.textContent = 'Unable to reach live leaderboard — displaying last known data.';
+        }
+      }
+    }
+
+    function buildLoadoutSnapshot() {
+      return Array.from(state.loadout.values()).map(item => ({
+        id: item.id,
+        name: item.name,
+        categoryId: item.categoryId,
+        categoryName: item.categoryName,
+        power: item.power,
+        cost: item.cost,
+        research: item.research
+      }));
+    }
+
+    function buildDefensePlan(level, stats) {
+      return {
+        timestamp: Date.now(),
+        level: level ? {
+          id: level.id,
+          name: level.name,
+          difficulty: level.difficulty,
+          impactLocation: level.impactLocation || null
+        } : null,
+        loadout: buildLoadoutSnapshot(),
+        totals: {
+          power: stats.totalPower,
+          creditsAllocated: state.initialCredits,
+          creditsRemaining: state.credits,
+          creditsSpent: state.initialCredits - state.credits,
+          missionCost: stats.spent,
+          damagePrevented: stats.prevented,
+          efficiency: stats.efficiency
+        }
+      };
+    }
+
+    function syncDefensePlan(plan) {
+      if (!plan) {
+        return;
+      }
+      window.__latestDefensePlan = plan;
+      try {
+        localStorage.setItem(DEFENSE_PLAN_STORAGE_KEY, JSON.stringify(plan));
+      } catch (storageError) {
+        console.warn('Failed to persist defense plan for visualization sync', storageError);
+      }
+      window.dispatchEvent(new CustomEvent('defenseStrategyUpdated', {
+        detail: {
+          plan,
+          source: 'defense-planner'
+        }
+      }));
     }
 
     function renderLevels() {
@@ -596,23 +805,28 @@
         wrapper.innerHTML = `<h3>${category.name}</h3>`;
 
         category.items.forEach(item => {
+          const loadoutItem = {
+            ...item,
+            categoryId: category.id,
+            categoryName: category.name
+          };
           const button = document.createElement('button');
           button.type = 'button';
           button.className = 'shop-item';
 
-          const unlocked = state.research >= item.research;
-          const affordable = state.credits >= item.cost;
-          const selected = state.loadout.has(item.id);
+          const unlocked = state.research >= loadoutItem.research;
+          const affordable = state.credits >= loadoutItem.cost;
+          const selected = state.loadout.has(loadoutItem.id);
 
           button.innerHTML = `
             <div class="item-header">
-              <strong>${item.name}</strong>
+              <strong>${loadoutItem.name}</strong>
             </div>
             <div class="item-meta">
-              <span>Level ${item.level}</span>
-              <span>Power +${item.power}</span>
-              <span>Cost ${formatCredits(item.cost)}</span>
-              <span>Research ${item.research}</span>
+              <span>Level ${loadoutItem.level}</span>
+              <span>Power +${loadoutItem.power}</span>
+              <span>Cost ${formatCredits(loadoutItem.cost)}</span>
+              <span>Research ${loadoutItem.research}</span>
             </div>
             <p>${unlocked ? 'Ready for deployment.' : 'Unlock with additional NASA research.'}</p>
           `;
@@ -631,7 +845,7 @@
             button.querySelector('p').textContent = 'Selected for launch.';
           }
 
-          button.addEventListener('click', () => toggleItem(item));
+          button.addEventListener('click', () => toggleItem(loadoutItem));
           wrapper.appendChild(button);
         });
 
@@ -657,8 +871,9 @@
 
     function toggleItem(item) {
       if (state.loadout.has(item.id)) {
+        const existing = state.loadout.get(item.id);
         state.loadout.delete(item.id);
-        state.credits += item.cost;
+        state.credits += existing.cost;
       } else {
         if (state.credits < item.cost || state.research < item.research) {
           return;
@@ -689,7 +904,7 @@
         container.innerHTML = `
           <strong>${item.name}</strong>
           <div class="item-meta">
-            <span>Category: ${getCategoryName(item.id)}</span>
+            <span>Category: ${item.categoryName ?? 'Classified'}</span>
             <span>Power +${item.power}</span>
             <span>Cost ${formatCredits(item.cost)}</span>
             <span>Research ${item.research}</span>
@@ -697,16 +912,6 @@
         `;
         selectedLoadout.appendChild(container);
       });
-    }
-
-    function getCategoryName(itemId) {
-      for (const category of categories) {
-        const found = category.items.find(item => item.id === itemId);
-        if (found) {
-          return category.name;
-        }
-      }
-      return 'Unknown';
     }
 
     function getTotalPower() {
@@ -736,13 +941,36 @@
 
     function renderLeaderboard() {
       leaderboardBody.innerHTML = '';
+      if (!currentLeaderboard.length) {
+        const emptyRow = document.createElement('tr');
+        emptyRow.className = 'empty';
+        const emptyCell = document.createElement('td');
+        emptyCell.colSpan = 6;
+        emptyCell.textContent = 'No leaderboard entries yet. Run a scenario to secure the top rank.';
+        emptyRow.appendChild(emptyCell);
+        leaderboardBody.appendChild(emptyRow);
+        return;
+      }
+
       currentLeaderboard.forEach((entry, idx) => {
         const row = document.createElement('tr');
+        if (entry.commander === 'You') {
+          row.classList.add('player-row');
+        }
+        let scoreText = '—';
+        if (Number.isFinite(entry.score)) {
+          scoreText = formatScore(entry.score);
+        } else if (Number.isFinite(entry.efficiency)) {
+          scoreText = `${entry.efficiency}%`;
+        }
+        const outcomeText = mergeOutcomeText(entry);
         row.innerHTML = `
           <td>${idx + 1}</td>
           <td>${entry.commander}</td>
-          <td>${entry.level}</td>
-          <td>${entry.efficiency}%</td>
+          <td>${scoreText}</td>
+          <td>${entry.method ?? '—'}</td>
+          <td>${entry.mission ?? '—'}</td>
+          <td>${outcomeText}</td>
         `;
         leaderboardBody.appendChild(row);
       });
@@ -754,22 +982,42 @@
       const totalPower = getTotalPower();
       const mitigationRatio = Math.min(totalPower / level.requiredPower, 1.35);
       const prevented = Math.round(level.baseDamage * mitigationRatio);
-      const spent = Math.max(0, (state.initialCredits - state.credits) * 1000);
+      const creditsSpent = Math.max(0, state.initialCredits - state.credits);
+      const spent = creditsSpent * 1000;
       const efficiency = spent > 0 ? Math.round((prevented / spent) * 100) : 0;
 
       damagePreventedEl.textContent = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(prevented) + ' lives saved';
-      missionCostEl.textContent = formatCredits(spent / 1000);
-      costEfficiencyEl.textContent = efficiency ? efficiency + ' %' : '—';
+      missionCostEl.textContent = formatCredits(creditsSpent);
+      costEfficiencyEl.textContent = efficiency ? `${efficiency} %` : '—';
 
-      currentLeaderboard = [
-        ...leaderboard.filter(entry => entry.commander !== 'You'),
-        { commander: 'You', level: level.name, efficiency }
-      ].sort((a, b) => b.efficiency - a.efficiency);
+      const outcomeBase = spent === 0
+        ? 'Training Run'
+        : (efficiency >= 100 ? 'Success' : (efficiency > 0 ? 'Partial' : 'Needs Review'));
+
+      const simulatedEntry = {
+        commander: 'You',
+        mission: level.name,
+        method: 'Custom Loadout',
+        score: prevented,
+        efficiency,
+        outcome: outcomeBase
+      };
+
+      const baseEntries = leaderboard.filter(entry => entry.commander !== 'You');
+      currentLeaderboard = [...baseEntries, simulatedEntry]
+        .sort((a, b) => getComparableScore(b) - getComparableScore(a));
 
       renderLeaderboard();
 
       const simulatedRank = currentLeaderboard.findIndex(entry => entry.commander === 'You');
       leaderboardRankEl.textContent = simulatedRank >= 0 ? '#' + (simulatedRank + 1) : '—';
+
+      const defensePlan = buildDefensePlan(level, { prevented, spent, efficiency, totalPower });
+      syncDefensePlan(defensePlan);
+
+      if (leaderboardStatus) {
+        leaderboardStatus.textContent = 'Defense plan synced — your run has been ranked above.';
+      }
 
       runScenarioButton.textContent = 'Scenario Complete';
       state.scenarioComplete = true;
@@ -802,6 +1050,7 @@
     renderLoadout();
     resetResultsDisplay();
     renderLeaderboard();
+    loadLeaderboard();
     updateLaunchState();
     syncStartButtons();
   </script>

--- a/astroyd-meteor-madness-main/defense-planner.html
+++ b/astroyd-meteor-madness-main/defense-planner.html
@@ -1,0 +1,809 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meteor Defense Planner</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0d1117;
+      --panel: rgba(20, 26, 33, 0.95);
+      --accent: #7b1fa2;
+      --accent-light: #ba68c8;
+      --text: #f1f5f9;
+      --muted: #94a3b8;
+      --border: rgba(148, 163, 184, 0.2);
+      --success: #10b981;
+      --warning: #f97316;
+      --danger: #ef4444;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top, rgba(123, 31, 162, 0.15), transparent 45%),
+                  radial-gradient(circle at bottom, rgba(59, 130, 246, 0.15), transparent 40%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 24px clamp(16px, 4vw, 64px) 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      background: linear-gradient(135deg, rgba(123, 31, 162, 0.25), rgba(15, 23, 42, 0.95));
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(12px);
+    }
+
+    header h1 {
+      margin: 0;
+      font-family: 'Orbitron', 'Roboto', sans-serif;
+      font-size: clamp(1.5rem, 1.2rem + 1.2vw, 2.5rem);
+      letter-spacing: 2px;
+    }
+
+    header p {
+      margin: 4px 0 0;
+      color: var(--muted);
+      max-width: 620px;
+      line-height: 1.4;
+    }
+
+    .hero-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .hero-actions button,
+    .hero-actions a {
+      border: none;
+      padding: 12px 18px;
+      border-radius: 999px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 150ms ease, box-shadow 150ms ease;
+      font-size: 0.8rem;
+    }
+
+    .primary-btn {
+      background: linear-gradient(135deg, var(--accent), var(--accent-light));
+      color: white;
+      box-shadow: 0 10px 25px rgba(123, 31, 162, 0.35);
+    }
+
+    .primary-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 30px rgba(123, 31, 162, 0.45);
+    }
+
+    .ghost-btn {
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--border);
+    }
+
+    .ghost-btn:hover {
+      color: var(--text);
+      transform: translateY(-2px);
+    }
+
+    main {
+      flex: 1;
+      padding: 24px clamp(16px, 4vw, 64px) 56px;
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    section {
+      background: var(--panel);
+      border-radius: 20px;
+      padding: 24px;
+      border: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    section::after {
+      content: "";
+      position: absolute;
+      inset: -20% 40% 40% -20%;
+      background: radial-gradient(circle at top right, rgba(123, 31, 162, 0.18), transparent 55%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    h2 {
+      font-family: 'Orbitron', 'Roboto', sans-serif;
+      margin: 0;
+      z-index: 1;
+      font-size: 1.1rem;
+      letter-spacing: 1px;
+    }
+
+    p {
+      margin: 0;
+      line-height: 1.5;
+      color: var(--muted);
+      z-index: 1;
+    }
+
+    .level-list,
+    .category-list,
+    .loadout-items,
+    .simulation-results,
+    .leaderboard {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      z-index: 1;
+    }
+
+    .level-card,
+    .shop-item {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 16px;
+      display: grid;
+      gap: 8px;
+      transition: border 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+      background: rgba(15, 23, 42, 0.6);
+    }
+
+    .level-card:hover,
+    .shop-item:hover {
+      border-color: var(--accent-light);
+      transform: translateY(-2px);
+      box-shadow: 0 12px 22px rgba(123, 31, 162, 0.15);
+    }
+
+    .level-card.active {
+      border-color: var(--accent-light);
+      box-shadow: 0 12px 22px rgba(123, 31, 162, 0.25);
+    }
+
+    .level-meta,
+    .item-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .tag {
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      background: rgba(123, 31, 162, 0.2);
+      color: var(--accent-light);
+    }
+
+    .shop-category {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .shop-category h3 {
+      margin: 0;
+      font-size: 0.95rem;
+      color: var(--accent-light);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .resource-summary {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      z-index: 1;
+    }
+
+    .resource-pill {
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.7);
+      font-size: 0.85rem;
+    }
+
+    .loadout-items .empty {
+      color: var(--muted);
+      text-align: center;
+      padding: 32px 0;
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+    }
+
+    .start-button {
+      margin-top: auto;
+      align-self: flex-start;
+      background: linear-gradient(135deg, #2563eb, #38bdf8);
+      color: white;
+      padding: 14px 32px;
+      border-radius: 999px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      border: none;
+      cursor: pointer;
+      text-transform: uppercase;
+      transition: transform 150ms ease, box-shadow 150ms ease;
+    }
+
+    .start-button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .start-button:not(:disabled):hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 28px rgba(37, 99, 235, 0.35);
+    }
+
+    .results-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .result-card {
+      padding: 16px;
+      border-radius: 14px;
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .result-card strong {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+    }
+
+    .result-value {
+      font-size: 1.3rem;
+      font-weight: 600;
+      color: white;
+    }
+
+    .leaderboard table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    .leaderboard th,
+    .leaderboard td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .leaderboard tbody tr:nth-child(odd) {
+      background: rgba(15, 23, 42, 0.5);
+    }
+
+    footer {
+      padding: 16px clamp(16px, 4vw, 64px) 32px;
+      text-align: center;
+      color: var(--muted);
+      border-top: 1px solid var(--border);
+      background: rgba(10, 12, 16, 0.9);
+      font-size: 0.85rem;
+    }
+
+    @media (max-width: 768px) {
+      header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .hero-actions {
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      main {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>Meteor Defense Planner</h1>
+      <p>Strategize NASA-backed planetary defense missions. Choose a level, invest in research-driven upgrades, and deploy the ultimate protection before the asteroid strikes.</p>
+    </div>
+    <div class="hero-actions">
+      <button class="primary-btn" id="start-simulation">Run Scenario</button>
+      <a href="index.html" class="ghost-btn">Back to Main Simulation</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="level-selection">
+      <h2>1 · Select a Pre-Made Threat Scenario</h2>
+      <p>Each level is based on curated asteroid impact data. Beat levels to earn mission funding and NASA research breakthroughs.</p>
+      <div class="level-list" id="levelList"></div>
+    </section>
+
+    <section id="shop">
+      <h2>2 · Assemble Your Defense System</h2>
+      <p>Invest in tech upgrades before launch. Spend your mission budget and research points to unlock advanced tools.</p>
+      <div class="resource-summary" id="resourceSummary"></div>
+      <div class="category-list" id="shopCategories"></div>
+    </section>
+
+    <section id="loadout">
+      <h2>3 · Launch Configuration</h2>
+      <p>Review your active defenses. Tune the loadout before you kick off the simulation.</p>
+      <div class="loadout-items" id="selectedLoadout">
+        <div class="empty">No systems selected yet. Choose items from the shop to build your response.</div>
+      </div>
+      <button class="start-button" id="launchScenario" disabled>Start Simulation</button>
+    </section>
+
+    <section id="results">
+      <h2>4 · Simulation Outcome</h2>
+      <p>Run the mission to see the projected damages, mission costs, and leaderboard standing.</p>
+      <div class="simulation-results" id="resultsContainer">
+        <div class="results-grid">
+          <div class="result-card">
+            <strong>Damage Prevented</strong>
+            <span class="result-value" id="damagePrevented">—</span>
+          </div>
+          <div class="result-card">
+            <strong>Mission Cost</strong>
+            <span class="result-value" id="missionCost">—</span>
+          </div>
+          <div class="result-card">
+            <strong>Cost Efficiency</strong>
+            <span class="result-value" id="costEfficiency">—</span>
+          </div>
+          <div class="result-card">
+            <strong>Leaderboard Rank</strong>
+            <span class="result-value" id="leaderboardRank">—</span>
+          </div>
+        </div>
+        <div class="leaderboard">
+          <h3>Global Response Leaderboard</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Commander</th>
+                <th>Level</th>
+                <th>Efficiency</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboardBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    NASA Space Apps · Meteor Madness Defense Game Prototype · Crafted for rapid mission planning previews.
+  </footer>
+
+  <script>
+    const levels = [
+      {
+        id: 'valles-marineris',
+        name: 'Valles Marineris Strike',
+        difficulty: 'Hard',
+        payout: { credits: 3200, research: 6 },
+        data: '648m carbonaceous asteroid on a Mars-skimming trajectory redirected toward Earth.',
+        baseDamage: 780000,
+        requiredPower: 120
+      },
+      {
+        id: 'aurora-borealis',
+        name: 'Aurora Borealis Window',
+        difficulty: 'Medium',
+        payout: { credits: 2200, research: 4 },
+        data: '392m iron-rich body entering at a polar inclination with high entry speed.',
+        baseDamage: 520000,
+        requiredPower: 85
+      },
+      {
+        id: 'pacific-guardian',
+        name: 'Pacific Guardian',
+        difficulty: 'Easy',
+        payout: { credits: 1400, research: 2 },
+        data: '190m stony asteroid projected to impact the northern Pacific shipping lanes.',
+        baseDamage: 260000,
+        requiredPower: 55
+      }
+    ];
+
+    const categories = [
+      {
+        id: 'lasers',
+        name: 'Orbital Lasers',
+        items: [
+          { id: 'laser-mk1', name: 'Helios Mk I', level: 1, research: 0, cost: 650, power: 28 },
+          { id: 'laser-mk2', name: 'Helios Mk II', level: 2, research: 2, cost: 950, power: 40 },
+          { id: 'laser-array', name: 'Apollo Array', level: 3, research: 4, cost: 1400, power: 60 }
+        ]
+      },
+      {
+        id: 'kinetics',
+        name: 'Kinetic Impactors',
+        items: [
+          { id: 'kinetic-duo', name: 'Atlas Twin-Strike', level: 1, research: 0, cost: 520, power: 20 },
+          { id: 'kinetic-swarm', name: 'Aegis Swarm', level: 2, research: 3, cost: 880, power: 36 },
+          { id: 'kinetic-precursor', name: 'Prometheus Precursor', level: 3, research: 5, cost: 1300, power: 55 }
+        ]
+      },
+      {
+        id: 'craft',
+        name: 'Autonomous Craft',
+        items: [
+          { id: 'craft-scout', name: 'Scout Drones', level: 1, research: 1, cost: 420, power: 12 },
+          { id: 'craft-interceptor', name: 'Interceptor Wing', level: 2, research: 3, cost: 780, power: 26 },
+          { id: 'craft-guardian', name: 'Guardian Fleet', level: 3, research: 6, cost: 1180, power: 44 }
+        ]
+      },
+      {
+        id: 'shields',
+        name: 'Planetary Shields',
+        items: [
+          { id: 'shield-atmo', name: 'Atmospheric Modulators', level: 1, research: 2, cost: 600, power: 18 },
+          { id: 'shield-ion', name: 'Ionospheric Guard', level: 2, research: 4, cost: 960, power: 32 },
+          { id: 'shield-planetary', name: 'Planetary Aegis', level: 3, research: 7, cost: 1500, power: 58 }
+        ]
+      }
+    ];
+
+    const leaderboard = [
+      { commander: 'Dr. Vega', level: 'Valles Marineris', efficiency: 92 },
+      { commander: 'Commander Imani', level: 'Aurora Borealis', efficiency: 88 },
+      { commander: 'Captain Singh', level: 'Pacific Guardian', efficiency: 81 },
+      { commander: 'Lt. Alvarez', level: 'Aurora Borealis', efficiency: 78 }
+    ];
+
+    let currentLeaderboard = [...leaderboard];
+
+    const progressionBase = { credits: 800, research: 1 };
+
+    const state = {
+      credits: 0,
+      research: 0,
+      selectedLevel: null,
+      loadout: new Map(),
+      initialCredits: 0,
+      scenarioComplete: false
+    };
+
+    const levelList = document.getElementById('levelList');
+    const resourceSummary = document.getElementById('resourceSummary');
+    const shopCategories = document.getElementById('shopCategories');
+    const selectedLoadout = document.getElementById('selectedLoadout');
+    const launchButton = document.getElementById('launchScenario');
+    const runScenarioButton = document.getElementById('start-simulation');
+
+    runScenarioButton.disabled = true;
+
+    const damagePreventedEl = document.getElementById('damagePrevented');
+    const missionCostEl = document.getElementById('missionCost');
+    const costEfficiencyEl = document.getElementById('costEfficiency');
+    const leaderboardRankEl = document.getElementById('leaderboardRank');
+    const leaderboardBody = document.getElementById('leaderboardBody');
+
+    function formatCredits(value) {
+      return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value * 1000);
+    }
+
+    function renderLevels() {
+      levelList.innerHTML = '';
+      levels.forEach(level => {
+        const card = document.createElement('button');
+        card.className = 'level-card';
+        card.type = 'button';
+        card.innerHTML = `
+          <div class="tag">${level.difficulty}</div>
+          <strong>${level.name}</strong>
+          <p>${level.data}</p>
+          <div class="level-meta">
+            <span>🛰 Required Power: <strong>${level.requiredPower}</strong></span>
+            <span>💰 Reward: <strong>${formatCredits(level.payout.credits)}</strong></span>
+            <span>🔬 Research: <strong>+${level.payout.research}</strong></span>
+          </div>
+        `;
+
+        if (state.selectedLevel && state.selectedLevel.id === level.id) {
+          card.classList.add('active');
+        }
+
+        card.addEventListener('click', () => selectLevel(level));
+
+        levelList.appendChild(card);
+      });
+    }
+
+    function selectLevel(level) {
+      state.selectedLevel = level;
+      state.credits = progressionBase.credits + level.payout.credits;
+      state.research = progressionBase.research + level.payout.research;
+      state.initialCredits = state.credits;
+      state.loadout.clear();
+      runScenarioButton.disabled = false;
+      Array.from(levelList.children).forEach(child => child.classList.remove('active'));
+      const activeCard = Array.from(levelList.children).find(child => child.textContent.includes(level.name));
+      if (activeCard) {
+        activeCard.classList.add('active');
+      }
+      markScenarioPending(true);
+      currentLeaderboard = [...leaderboard];
+      renderResources();
+      renderShop();
+      renderLoadout();
+      renderLeaderboard();
+      updateLaunchState();
+    }
+
+    function renderResources() {
+      resourceSummary.innerHTML = '';
+      const creditPill = document.createElement('span');
+      creditPill.className = 'resource-pill';
+      creditPill.textContent = `Mission Budget: ${formatCredits(state.credits)}`;
+
+      const researchPill = document.createElement('span');
+      researchPill.className = 'resource-pill';
+      researchPill.textContent = `NASA Research Points: ${state.research}`;
+
+      const powerPill = document.createElement('span');
+      powerPill.className = 'resource-pill';
+      powerPill.textContent = `Total Defense Power: ${getTotalPower()}`;
+
+      resourceSummary.append(creditPill, researchPill, powerPill);
+    }
+
+    function renderShop() {
+      shopCategories.innerHTML = '';
+      categories.forEach(category => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'shop-category';
+        wrapper.innerHTML = `<h3>${category.name}</h3>`;
+
+        category.items.forEach(item => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'shop-item';
+
+          const unlocked = state.research >= item.research;
+          const affordable = state.credits >= item.cost;
+          const selected = state.loadout.has(item.id);
+
+          button.innerHTML = `
+            <div class="item-header">
+              <strong>${item.name}</strong>
+            </div>
+            <div class="item-meta">
+              <span>Level ${item.level}</span>
+              <span>Power +${item.power}</span>
+              <span>Cost ${formatCredits(item.cost)}</span>
+              <span>Research ${item.research}</span>
+            </div>
+            <p>${unlocked ? 'Ready for deployment.' : 'Unlock with additional NASA research.'}</p>
+          `;
+
+          if (!unlocked) {
+            button.disabled = true;
+            button.style.opacity = 0.5;
+          } else if (!affordable && !selected) {
+            button.disabled = true;
+            button.style.opacity = 0.6;
+            button.querySelector('p').textContent = 'Insufficient mission budget.';
+          }
+
+          if (selected) {
+            button.classList.add('active');
+            button.querySelector('p').textContent = 'Selected for launch.';
+          }
+
+          button.addEventListener('click', () => toggleItem(item));
+          wrapper.appendChild(button);
+        });
+
+        shopCategories.appendChild(wrapper);
+      });
+    }
+
+    function resetResultsDisplay() {
+      damagePreventedEl.textContent = '—';
+      missionCostEl.textContent = '—';
+      costEfficiencyEl.textContent = '—';
+      leaderboardRankEl.textContent = '—';
+    }
+
+    function markScenarioPending(forceReset = false) {
+      if (state.scenarioComplete || forceReset) {
+        state.scenarioComplete = false;
+        runScenarioButton.textContent = 'Run Scenario';
+        launchButton.textContent = 'Start Simulation';
+        resetResultsDisplay();
+      }
+    }
+
+    function toggleItem(item) {
+      if (state.loadout.has(item.id)) {
+        state.loadout.delete(item.id);
+        state.credits += item.cost;
+      } else {
+        if (state.credits < item.cost || state.research < item.research) {
+          return;
+        }
+        state.loadout.set(item.id, item);
+        state.credits -= item.cost;
+      }
+      markScenarioPending();
+      renderResources();
+      renderShop();
+      renderLoadout();
+      updateLaunchState();
+    }
+
+    function renderLoadout() {
+      selectedLoadout.innerHTML = '';
+      if (state.loadout.size === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'empty';
+        empty.textContent = 'No systems selected yet. Choose items from the shop to build your response.';
+        selectedLoadout.appendChild(empty);
+        return;
+      }
+
+      state.loadout.forEach(item => {
+        const container = document.createElement('div');
+        container.className = 'shop-item';
+        container.innerHTML = `
+          <strong>${item.name}</strong>
+          <div class="item-meta">
+            <span>Category: ${getCategoryName(item.id)}</span>
+            <span>Power +${item.power}</span>
+            <span>Cost ${formatCredits(item.cost)}</span>
+            <span>Research ${item.research}</span>
+          </div>
+        `;
+        selectedLoadout.appendChild(container);
+      });
+    }
+
+    function getCategoryName(itemId) {
+      for (const category of categories) {
+        const found = category.items.find(item => item.id === itemId);
+        if (found) {
+          return category.name;
+        }
+      }
+      return 'Unknown';
+    }
+
+    function getTotalPower() {
+      let power = 0;
+      state.loadout.forEach(item => {
+        power += item.power;
+      });
+      return power;
+    }
+
+    function updateLaunchState() {
+      const hasLevel = Boolean(state.selectedLevel);
+      const powerSufficient = state.selectedLevel ? getTotalPower() >= state.selectedLevel.requiredPower : false;
+      if (!hasLevel) {
+        launchButton.disabled = true;
+        launchButton.textContent = 'Select a Level';
+        return;
+      }
+
+      launchButton.disabled = !(hasLevel && powerSufficient);
+      if (state.scenarioComplete) {
+        launchButton.textContent = 'Simulation Complete';
+      } else {
+        launchButton.textContent = powerSufficient ? 'Start Simulation' : 'Add More Power';
+      }
+    }
+
+    function renderLeaderboard() {
+      leaderboardBody.innerHTML = '';
+      currentLeaderboard.forEach((entry, idx) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${idx + 1}</td>
+          <td>${entry.commander}</td>
+          <td>${entry.level}</td>
+          <td>${entry.efficiency}%</td>
+        `;
+        leaderboardBody.appendChild(row);
+      });
+    }
+
+    function runSimulation() {
+      if (!state.selectedLevel) return;
+      const level = state.selectedLevel;
+      const totalPower = getTotalPower();
+      const mitigationRatio = Math.min(totalPower / level.requiredPower, 1.35);
+      const prevented = Math.round(level.baseDamage * mitigationRatio);
+      const spent = Math.max(0, (state.initialCredits - state.credits) * 1000);
+      const efficiency = spent > 0 ? Math.round((prevented / spent) * 100) : 0;
+
+      damagePreventedEl.textContent = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(prevented) + ' lives saved';
+      missionCostEl.textContent = formatCredits(spent / 1000);
+      costEfficiencyEl.textContent = efficiency ? efficiency + ' %' : '—';
+
+      currentLeaderboard = [
+        ...leaderboard.filter(entry => entry.commander !== 'You'),
+        { commander: 'You', level: level.name, efficiency }
+      ].sort((a, b) => b.efficiency - a.efficiency);
+
+      renderLeaderboard();
+
+      const simulatedRank = currentLeaderboard.findIndex(entry => entry.commander === 'You');
+      leaderboardRankEl.textContent = simulatedRank >= 0 ? '#' + (simulatedRank + 1) : '—';
+
+      runScenarioButton.textContent = 'Scenario Complete';
+      state.scenarioComplete = true;
+      updateLaunchState();
+    }
+
+    function syncStartButtons() {
+      runScenarioButton.addEventListener('click', () => {
+        if (!state.selectedLevel) {
+          alert('Select a level and configure your defenses first.');
+          return;
+        }
+
+        if (launchButton.disabled && !state.scenarioComplete) {
+          alert('Add enough defense power to meet the mission requirements.');
+          return;
+        }
+
+        launchButton.click();
+      });
+
+      launchButton.addEventListener('click', () => {
+        runSimulation();
+      });
+    }
+
+    renderLevels();
+    renderResources();
+    renderShop();
+    renderLoadout();
+    resetResultsDisplay();
+    renderLeaderboard();
+    updateLaunchState();
+    syncStartButtons();
+  </script>
+</body>
+</html>

--- a/astroyd-meteor-madness-main/defense-planner.html
+++ b/astroyd-meteor-madness-main/defense-planner.html
@@ -760,7 +760,10 @@
       window.dispatchEvent(new CustomEvent('defenseStrategyUpdated', {
         detail: {
           plan,
-          source: 'defense-planner'
+          meta: {
+            source: 'defense-planner',
+            autoFollow: true
+          }
         }
       }));
     }
@@ -1042,7 +1045,7 @@
       const accuracyDisplay = Number.isFinite(totals.accuracy) ? Math.round(totals.accuracy) : null;
       const summary = totals.success
         ? `Defense intercept succeeded with${accuracyDisplay !== null ? ` ${accuracyDisplay}%` : ''} accuracy.`
-        : `Defense window missed — accuracy${accuracyDisplay !== null ? ` ${accuracyDisplay}%` : ''} below required threshold.`;
+        : `Defense window missed — accuracy${accuracyDisplay !== null ? ` ${accuracyDisplay}%` : ''} below required 90% threshold.`;
       return {
         approachPoint: approach,
         interceptPoint,
@@ -1065,7 +1068,7 @@
       const synergyBonus = clamp(state.loadout.size * 4.5, 0, 18);
       const randomness = Math.random() * 18 - 6;
       const accuracy = clamp(Math.round(accuracyBase + synergyBonus + randomness), 0, 100);
-      const success = accuracy >= 20;
+      const success = accuracy >= 90;
       const prevented = success
         ? Math.round(level.baseDamage * mitigationRatio * (accuracy / 100))
         : 0;

--- a/astroyd-meteor-madness-main/defense-planner.html
+++ b/astroyd-meteor-madness-main/defense-planner.html
@@ -456,7 +456,8 @@
         data: '648m carbonaceous asteroid on a Mars-skimming trajectory redirected toward Earth.',
         baseDamage: 780000,
         requiredPower: 120,
-        impactLocation: { latitude: 15.4, longitude: -74.6, elevation: 0 }
+        impactLocation: { latitude: 15.4, longitude: -74.6, elevation: 0 },
+        approachVector: { latitude: 9.2, longitude: -94.8, altitude: 520000 }
       },
       {
         id: 'aurora-borealis',
@@ -466,7 +467,8 @@
         data: '392m iron-rich body entering at a polar inclination with high entry speed.',
         baseDamage: 520000,
         requiredPower: 85,
-        impactLocation: { latitude: 69.6, longitude: -96.8, elevation: 0 }
+        impactLocation: { latitude: 69.6, longitude: -96.8, elevation: 0 },
+        approachVector: { latitude: 80.4, longitude: -124.3, altitude: 610000 }
       },
       {
         id: 'pacific-guardian',
@@ -476,7 +478,8 @@
         data: '190m stony asteroid projected to impact the northern Pacific shipping lanes.',
         baseDamage: 260000,
         requiredPower: 55,
-        impactLocation: { latitude: 24.5, longitude: -151.6, elevation: 0 }
+        impactLocation: { latitude: 24.5, longitude: -151.6, elevation: 0 },
+        approachVector: { latitude: 32.8, longitude: -175.2, altitude: 430000 }
       }
     ];
 
@@ -559,6 +562,8 @@
     const leaderboardBody = document.getElementById('leaderboardBody');
     const leaderboardStatus = document.getElementById('leaderboardStatus');
 
+    const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
     function formatCredits(value) {
       return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value * 1000);
     }
@@ -577,6 +582,12 @@
       }
       if (Number.isFinite(entry?.efficiency)) {
         parts.push(`${entry.efficiency}% eff.`);
+      }
+      if (Number.isFinite(entry?.successRate)) {
+        parts.push(`${Math.round(entry.successRate * 100)}% intercept rate`);
+      }
+      if (Number.isFinite(entry?.gamesPlayed)) {
+        parts.push(`${entry.gamesPlayed} runs`);
       }
       return parts.length ? parts.join(' · ') : '—';
     }
@@ -600,17 +611,23 @@
       }
       const commander = entry.player_name || entry.username || entry.commander || entry.full_name || `Commander ${index + 1}`;
       const mission = entry.mission || entry.level || entry.level_name || entry.difficulty_level || entry.target || entry.scenario || '—';
-      const method = entry.deflection_method || entry.method || entry.strategy || '—';
-      const rawScore = Number.parseFloat(entry.score);
+      const methodSource = entry.deflection_method || entry.favorite_method || entry.method || entry.strategy;
+      const method = methodSource || '—';
+      const rawScore = Number.parseFloat(entry.score ?? entry.best_score);
       const score = Number.isFinite(rawScore) ? rawScore : null;
       const efficiencySource = entry.efficiency ?? entry.cost_efficiency ?? entry.success_rate;
       let efficiency = null;
       if (Number.isFinite(efficiencySource)) {
         efficiency = Math.round(efficiencySource * (efficiencySource <= 1 ? 100 : 1));
       }
-      const outcome = entry.outcome
+      let outcome = entry.outcome
         || (typeof entry.success === 'boolean' ? (entry.success ? 'Success' : 'Failed') : null)
         || (typeof entry.success_rate === 'number' ? `${Math.round(entry.success_rate * 100)}% success` : null);
+
+      const gamesPlayed = Number.isFinite(entry.games_played) ? entry.games_played : (Number.isFinite(entry.games) ? entry.games : null);
+      if (gamesPlayed === 0 && !outcome) {
+        outcome = 'Awaiting first run';
+      }
 
       return {
         commander,
@@ -619,6 +636,9 @@
         score,
         efficiency,
         outcome,
+        rank: Number.isFinite(entry.rank) ? entry.rank : null,
+        gamesPlayed,
+        successRate: Number.isFinite(entry.success_rate) ? entry.success_rate : null,
         raw: entry
       };
     }
@@ -627,7 +647,16 @@
       const normalized = entries
         .filter(Boolean)
         .map(entry => ({ ...entry }))
-        .sort((a, b) => getComparableScore(b) - getComparableScore(a));
+        .sort((a, b) => {
+          const rankA = Number.isFinite(a.rank) ? a.rank : null;
+          const rankB = Number.isFinite(b.rank) ? b.rank : null;
+          if (rankA !== null && rankB !== null) {
+            return rankA - rankB;
+          }
+          if (rankA !== null) return -1;
+          if (rankB !== null) return 1;
+          return getComparableScore(b) - getComparableScore(a);
+        });
       leaderboard.length = 0;
       normalized.forEach(entry => leaderboard.push(entry));
       currentLeaderboard = [...leaderboard];
@@ -692,14 +721,15 @@
       }));
     }
 
-    function buildDefensePlan(level, stats) {
+    function buildDefensePlan(level, stats, engagement) {
       return {
         timestamp: Date.now(),
         level: level ? {
           id: level.id,
           name: level.name,
           difficulty: level.difficulty,
-          impactLocation: level.impactLocation || null
+          impactLocation: level.impactLocation || null,
+          approachVector: level.approachVector || null
         } : null,
         loadout: buildLoadoutSnapshot(),
         totals: {
@@ -709,8 +739,11 @@
           creditsSpent: state.initialCredits - state.credits,
           missionCost: stats.spent,
           damagePrevented: stats.prevented,
-          efficiency: stats.efficiency
-        }
+          efficiency: stats.efficiency,
+          accuracy: stats.accuracy,
+          success: Boolean(stats.success)
+        },
+        engagement: engagement || null
       };
     }
 
@@ -964,8 +997,12 @@
           scoreText = `${entry.efficiency}%`;
         }
         const outcomeText = mergeOutcomeText(entry);
+        const hasComparableScore = Number.isFinite(entry.score) || Number.isFinite(entry.efficiency);
+        const rankDisplay = Number.isFinite(entry.rank)
+          ? entry.rank
+          : (entry.commander === 'You' ? (idx + 1) : (hasComparableScore ? idx + 1 : '—'));
         row.innerHTML = `
-          <td>${idx + 1}</td>
+          <td>${rankDisplay}</td>
           <td>${entry.commander}</td>
           <td>${scoreText}</td>
           <td>${entry.method ?? '—'}</td>
@@ -976,23 +1013,75 @@
       });
     }
 
+    function computeEngagement(level, totals) {
+      const impact = level.impactLocation || { latitude: 0, longitude: 0, elevation: 0 };
+      const approach = level.approachVector || {
+        latitude: clamp(impact.latitude + 8, -80, 80),
+        longitude: impact.longitude - 18,
+        altitude: 480000
+      };
+      const interceptBlend = totals.success ? 0.58 : 0.72;
+      const interceptLat = approach.latitude + (impact.latitude - approach.latitude) * interceptBlend;
+      const interceptLon = approach.longitude + (impact.longitude - approach.longitude) * interceptBlend;
+      const interceptAlt = clamp(approach.altitude * 0.68, 160000, 680000);
+      const interceptPoint = {
+        latitude: clamp(interceptLat, -85, 85),
+        longitude: interceptLon,
+        altitude: interceptAlt
+      };
+      const missPoint = {
+        latitude: clamp(interceptPoint.latitude - 2.4, -85, 85),
+        longitude: interceptPoint.longitude + 6,
+        altitude: clamp(interceptPoint.altitude * 0.75, 80000, 420000)
+      };
+      const deflectionPoint = {
+        latitude: clamp(interceptPoint.latitude + 3.2, -85, 85),
+        longitude: interceptPoint.longitude + 4.5,
+        altitude: clamp(interceptPoint.altitude + 190000, 200000, 780000)
+      };
+      const accuracyDisplay = Number.isFinite(totals.accuracy) ? Math.round(totals.accuracy) : null;
+      const summary = totals.success
+        ? `Defense intercept succeeded with${accuracyDisplay !== null ? ` ${accuracyDisplay}%` : ''} accuracy.`
+        : `Defense window missed — accuracy${accuracyDisplay !== null ? ` ${accuracyDisplay}%` : ''} below required threshold.`;
+      return {
+        approachPoint: approach,
+        interceptPoint,
+        missPoint,
+        deflectionPoint,
+        success: totals.success,
+        accuracy: totals.accuracy,
+        summary,
+        outcome: totals.success ? 'intercepted' : 'missed'
+      };
+    }
+
     function runSimulation() {
       if (!state.selectedLevel) return;
       const level = state.selectedLevel;
       const totalPower = getTotalPower();
-      const mitigationRatio = Math.min(totalPower / level.requiredPower, 1.35);
-      const prevented = Math.round(level.baseDamage * mitigationRatio);
+      const powerRatio = totalPower / Math.max(level.requiredPower, 1);
+      const mitigationRatio = Math.min(powerRatio, 1.4);
+      const accuracyBase = clamp(powerRatio * 62, 6, 92);
+      const synergyBonus = clamp(state.loadout.size * 4.5, 0, 18);
+      const randomness = Math.random() * 18 - 6;
+      const accuracy = clamp(Math.round(accuracyBase + synergyBonus + randomness), 0, 100);
+      const success = accuracy >= 20;
+      const prevented = success
+        ? Math.round(level.baseDamage * mitigationRatio * (accuracy / 100))
+        : 0;
       const creditsSpent = Math.max(0, state.initialCredits - state.credits);
       const spent = creditsSpent * 1000;
       const efficiency = spent > 0 ? Math.round((prevented / spent) * 100) : 0;
 
-      damagePreventedEl.textContent = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(prevented) + ' lives saved';
+      damagePreventedEl.textContent = success
+        ? new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(prevented) + ' lives saved'
+        : 'Defense failed — impact imminent';
       missionCostEl.textContent = formatCredits(creditsSpent);
       costEfficiencyEl.textContent = efficiency ? `${efficiency} %` : '—';
 
-      const outcomeBase = spent === 0
-        ? 'Training Run'
-        : (efficiency >= 100 ? 'Success' : (efficiency > 0 ? 'Partial' : 'Needs Review'));
+      const outcomeBase = !success
+        ? 'Defense Failed'
+        : (efficiency >= 120 ? 'Intercept Success' : (efficiency > 0 ? 'Intercept Partial' : 'Intercept Logged'));
 
       const simulatedEntry = {
         commander: 'You',
@@ -1000,7 +1089,10 @@
         method: 'Custom Loadout',
         score: prevented,
         efficiency,
-        outcome: outcomeBase
+        outcome: `${outcomeBase} · Accuracy ${accuracy}%`,
+        gamesPlayed: 1,
+        successRate: success ? 1 : 0,
+        success
       };
 
       const baseEntries = leaderboard.filter(entry => entry.commander !== 'You');
@@ -1012,7 +1104,8 @@
       const simulatedRank = currentLeaderboard.findIndex(entry => entry.commander === 'You');
       leaderboardRankEl.textContent = simulatedRank >= 0 ? '#' + (simulatedRank + 1) : '—';
 
-      const defensePlan = buildDefensePlan(level, { prevented, spent, efficiency, totalPower });
+      const engagement = computeEngagement(level, { accuracy, success });
+      const defensePlan = buildDefensePlan(level, { prevented, spent, efficiency, totalPower, accuracy, success }, engagement);
       syncDefensePlan(defensePlan);
 
       if (leaderboardStatus) {

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -385,6 +385,57 @@
     const api = new MeteorMadnessAPI();
     let cachedHistory = [];
 
+    const DEFENSE_PLAN_STORAGE_KEY = 'defensePlanner:lastConfiguration';
+
+    const safeParseJson = (value) => {
+      if (typeof value !== 'string' || !value.length) {
+        return null;
+      }
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        console.warn('Failed to parse defense plan payload', error);
+        return null;
+      }
+    };
+
+    const dispatchDefensePlanUpdate = (plan, meta = {}) => {
+      if (!plan || typeof plan !== 'object') {
+        return;
+      }
+      window.__latestDefensePlan = plan;
+      window.dispatchEvent(new CustomEvent('defenseStrategyUpdated', {
+        detail: {
+          plan,
+          meta: {
+            ...meta,
+            receivedAt: Date.now()
+          }
+        }
+      }));
+    };
+
+    const bootstrapDefensePlanSync = () => {
+      if (typeof localStorage === 'undefined') {
+        return;
+      }
+      const cachedPlan = localStorage.getItem(DEFENSE_PLAN_STORAGE_KEY);
+      const parsed = safeParseJson(cachedPlan);
+      if (parsed) {
+        dispatchDefensePlanUpdate(parsed, { source: 'bootstrap' });
+      }
+    };
+
+    window.addEventListener('storage', (event) => {
+      if (event.key !== DEFENSE_PLAN_STORAGE_KEY || !event.newValue) {
+        return;
+      }
+      const parsed = safeParseJson(event.newValue);
+      if (parsed) {
+        dispatchDefensePlanUpdate(parsed, { source: 'storage' });
+      }
+    });
+
     const damageMetricsContainer = document.getElementById('damageMetrics');
     const damageMetricsContent = document.getElementById('damageMetricsContent');
     const defaultDamageMetricsMessage = damageMetricsContent
@@ -850,6 +901,7 @@
     //     }
     // });
 
+    bootstrapDefensePlanSync();
     checkBackendConnection();
     setupCesiumVisualization('cesiumContainer');
 

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -679,12 +679,17 @@
           composition: document.getElementById('composition').value
         };
 
+          const populationDensityInput = parseFloat(document.getElementById('population_density').value);
+        const populationDensity = Number.isFinite(populationDensityInput) ? populationDensityInput : 0;
+
         const impactLocation = {
           latitude: parseFloat(document.getElementById('latitude').value),
           longitude: parseFloat(document.getElementById('longitude').value),
           elevation: parseFloat(document.getElementById('elevation').value),
-          terrain_type: document.getElementById('terrain_type').value
+          terrain_type: document.getElementById('terrain_type').value,
+          population_density: populationDensity
         };
+
 
         const simulationResult = await api.simulateImpact(asteroidData, impactLocation);
 
@@ -699,7 +704,9 @@
             longitude: impactLocation.longitude,
             elevation: impactLocation.elevation,
             terrain_type: impactLocation.terrain_type,
-            population_density: simulationResult.impact_location?.population_density ?? impactLocation.population_density ?? 0,
+             population_density: Number.isFinite(simulationResult.impact_location?.population_density)
+              ? simulationResult.impact_location.population_density
+              : populationDensity,
             blast_radius: impactResult.blast_radius ?? DEFAULT_SIMULATION.location.blast_radius,
             crater_diameter: impactResult.crater_diameter ?? DEFAULT_SIMULATION.location.crater_diameter,
             thermal_radius: impactResult.thermal_radius ?? DEFAULT_SIMULATION.location.thermal_radius,
@@ -1111,4 +1118,5 @@
     });
   </script>
 </body>
+
 </html>

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -291,6 +291,10 @@
       <label for="evacuation_radius">Evacuation Radius (m):</label>
       <input type="number" id="evacuation_radius" name="evacuation_radius" step="1" value="100000" style="width:80px;margin-bottom:8px"><br>
     </form>
+    <div id="damageMetrics" style="margin-top:16px;padding:12px;background:rgba(0,0,0,0.05);border-radius:6px;">
+      <h4 style="margin:0 0 8px;font-size:14px;">Damage Assessment</h4>
+      <div id="damageMetricsContent" style="font-size:12px;color:#333;">Run the advanced metrics to view estimated damage outcomes.</div>
+    </div>
   </div>
   <div id="neoListContainer" style="position:absolute;top:60px;right:10px;width:320px;max-height:400px;overflow-y:auto;background:rgba(255,255,255,0.95);padding:10px;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,0.12);display:none;">
     <h3 style="margin-top:0;">Select NEO Template</h3>
@@ -302,6 +306,7 @@
   <button id="neoToggleButton" type="button">Show NEOs</button>
   <button id="launchButton" type="button">Launch Simulation</button>
   <button id="advanced-calculation" type="button" style="position:absolute;top:10px;left:600px;z-index:1000;padding:10px 20px;background:rgba(34,139,34,0.85);border:none;color:white;cursor:pointer;border-radius:4px;font-size:14px;">Advanced Metrics</button>
+  <button id="defense-planner-button" type="button" style="position:absolute;top:10px;left:760px;z-index:1000;padding:10px 20px;background:rgba(123, 31, 162, 0.85);border:none;color:white;cursor:pointer;border-radius:4px;font-size:14px;">Defense Planner</button>
   <script type="module">
     import { setupCesiumVisualization } from './cesium-visualization.js';
     import { MeteorMadnessAPI } from './api-client.js';
@@ -320,6 +325,16 @@
       }
       const parsed = parseFloat(element.value);
       return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    const setNumericInputValue = (elementId, value) => {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return;
+      }
+      const element = document.getElementById(elementId);
+      if (element) {
+        element.value = value;
+      }
     };
 
     const DEFAULT_SIMULATION = {
@@ -361,13 +376,123 @@
         affected_area: 0
       },
       metadata: null,
-      simulationId: null
+      simulationId: null,
+      damageAssessment: null
     };
 
     let latestSimulation = clone(DEFAULT_SIMULATION);
 
     const api = new MeteorMadnessAPI();
     let cachedHistory = [];
+
+    const damageMetricsContainer = document.getElementById('damageMetrics');
+    const damageMetricsContent = document.getElementById('damageMetricsContent');
+    const defaultDamageMetricsMessage = damageMetricsContent
+      ? damageMetricsContent.textContent
+      : 'Run the advanced metrics to view estimated damage outcomes.';
+
+    const formatMetricLabel = (label) => label
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (match) => match.toUpperCase());
+
+    const appendMetricValue = (parent, value) => {
+      if (!parent) {
+        return;
+      }
+
+      if (value === null || value === undefined) {
+        parent.appendChild(document.createTextNode('N/A'));
+        return;
+      }
+
+      if (typeof value === 'number') {
+        const abs = Math.abs(value);
+        const formatted = value.toLocaleString(undefined, {
+          maximumFractionDigits: abs >= 1000 ? 2 : 3
+        });
+        parent.appendChild(document.createTextNode(formatted));
+        return;
+      }
+
+      if (typeof value === 'boolean') {
+        parent.appendChild(document.createTextNode(value ? 'Yes' : 'No'));
+        return;
+      }
+
+      if (typeof value === 'string') {
+        parent.appendChild(document.createTextNode(value));
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          parent.appendChild(document.createTextNode('N/A'));
+          return;
+        }
+        const list = document.createElement('ul');
+        list.style.listStyle = 'disc';
+        list.style.margin = '4px 0 4px 16px';
+        list.style.padding = '0';
+        value.forEach((item) => {
+          const li = document.createElement('li');
+          appendMetricValue(li, item);
+          list.appendChild(li);
+        });
+        parent.appendChild(list);
+        return;
+      }
+
+      const list = document.createElement('ul');
+      list.style.listStyle = 'none';
+      list.style.padding = '0';
+      list.style.margin = '4px 0';
+      Object.entries(value).forEach(([key, nestedValue]) => {
+        const li = document.createElement('li');
+        li.style.marginBottom = '6px';
+        const labelEl = document.createElement('strong');
+        labelEl.textContent = `${formatMetricLabel(key)}:`;
+        li.appendChild(labelEl);
+        li.appendChild(document.createTextNode(' '));
+        appendMetricValue(li, nestedValue);
+        list.appendChild(li);
+      });
+      parent.appendChild(list);
+    };
+
+    const renderDamageMetrics = (advancedResult, { loading = false, error = null } = {}) => {
+      if (!damageMetricsContainer || !damageMetricsContent) {
+        return;
+      }
+
+      damageMetricsContainer.style.display = 'block';
+      damageMetricsContent.innerHTML = '';
+
+      if (loading) {
+        damageMetricsContent.textContent = 'Calculating advanced metrics...';
+        return;
+      }
+
+      if (error) {
+        damageMetricsContent.textContent = error;
+        return;
+      }
+
+      const damageAssessment = advancedResult?.damage_assessment
+        ?? advancedResult?.damageAssessment
+        ?? advancedResult?.damage_metrics;
+      if (!damageAssessment || (typeof damageAssessment === 'object' && !Array.isArray(damageAssessment) && Object.keys(damageAssessment).length === 0)) {
+        damageMetricsContent.textContent = defaultDamageMetricsMessage;
+        return;
+      }
+
+      appendMetricValue(damageMetricsContent, damageAssessment);
+    };
+
+    window.addEventListener('advancedImpactCalculated', (event) => {
+      if (event?.detail) {
+        renderDamageMetrics(event.detail);
+      }
+    });
 
     const renderHistoryTable = (history) => {
       const tableBody = document.getElementById('historyTableBody');
@@ -490,8 +615,11 @@
             atmospheric_effects: impactResult.atmospheric_effects ?? DEFAULT_SIMULATION.impactResult.atmospheric_effects
           },
           metadata: simulationResult.simulation_metadata ?? null,
-          simulationId: simulationResult.simulation_id ?? null
+          simulationId: simulationResult.simulation_id ?? null,
+          damageAssessment: null
         };
+
+        renderDamageMetrics(null);
 
         const latestImpactResult = latestSimulation.impactResult || {};
 
@@ -552,6 +680,8 @@
         advancedCalculationButton.textContent = 'Calculating...';
         advancedCalculationButton.disabled = true;
 
+        renderDamageMetrics(null, { loading: true });
+
         const latitude = getNumericValue('latitude', latestSimulation.location.latitude);
         const longitude = getNumericValue('longitude', latestSimulation.location.longitude);
         const elevation = getNumericValue('elevation', latestSimulation.location.elevation);
@@ -605,7 +735,84 @@
             }
           }
 
-          window.dispatchEvent(new CustomEvent('advancedImpactCalculated', { detail: clone(advancedResult) }));
+          const advancedImpactResult = advancedResult?.impact_result ?? {};
+          const advancedImpactLocation = advancedResult?.impact_location ?? {};
+          const damageAssessment = advancedResult?.damage_assessment ?? null;
+
+          const previousImpactResult = latestSimulation.impactResult || {};
+          const mergedImpactResult = {
+            ...DEFAULT_SIMULATION.impactResult,
+            ...previousImpactResult,
+            ...advancedImpactResult,
+            impact_zones: Array.isArray(advancedImpactResult.impact_zones)
+              ? advancedImpactResult.impact_zones
+              : (Array.isArray(previousImpactResult.impact_zones)
+                ? previousImpactResult.impact_zones
+                : DEFAULT_SIMULATION.impactResult.impact_zones),
+            atmospheric_effects: advancedImpactResult.atmospheric_effects
+              ?? previousImpactResult.atmospheric_effects
+              ?? DEFAULT_SIMULATION.impactResult.atmospheric_effects
+          };
+
+          const mergedLocation = {
+            ...latestSimulation.location,
+            ...advancedImpactLocation
+          };
+
+          if (typeof resolvedDensity === 'number' && Number.isFinite(resolvedDensity)) {
+            mergedLocation.population_density = resolvedDensity;
+          }
+
+          const propagateMetrics = ['crater_diameter', 'blast_radius', 'thermal_radius', 'fireball_radius', 'evacuation_radius'];
+          propagateMetrics.forEach((metric) => {
+            const metricValue = mergedImpactResult[metric];
+            if (typeof metricValue === 'number' && Number.isFinite(metricValue)) {
+              mergedLocation[metric] = metricValue;
+              setNumericInputValue(metric, metricValue);
+            }
+          });
+
+          if (typeof mergedLocation.latitude === 'number' && Number.isFinite(mergedLocation.latitude)) {
+            setNumericInputValue('latitude', mergedLocation.latitude);
+          }
+          if (typeof mergedLocation.longitude === 'number' && Number.isFinite(mergedLocation.longitude)) {
+            setNumericInputValue('longitude', mergedLocation.longitude);
+          }
+          if (typeof mergedLocation.elevation === 'number' && Number.isFinite(mergedLocation.elevation)) {
+            setNumericInputValue('elevation', mergedLocation.elevation);
+          }
+
+          if (terrainSelect && typeof mergedLocation.terrain_type === 'string') {
+            terrainSelect.value = mergedLocation.terrain_type;
+          }
+
+          const advancedMetadata = advancedResult?.simulation_metadata ?? advancedResult?.metadata ?? latestSimulation.metadata ?? null;
+          const advancedSimulationId = advancedResult?.simulation_id ?? advancedResult?.simulationId ?? latestSimulation.simulationId ?? null;
+
+          latestSimulation = {
+            ...latestSimulation,
+            location: mergedLocation,
+            impactResult: mergedImpactResult,
+            damageAssessment: damageAssessment ?? latestSimulation.damageAssessment ?? null,
+            metadata: advancedMetadata,
+            simulationId: advancedSimulationId
+          };
+
+          window.dispatchEvent(new CustomEvent('impactSettingsChanged', { detail: clone(latestSimulation) }));
+
+          renderDamageMetrics(advancedResult);
+
+          let advancedEventPayload = advancedResult ? clone(advancedResult) : {};
+          if (typeof advancedEventPayload !== 'object' || advancedEventPayload === null) {
+            advancedEventPayload = {
+              simulation: clone(latestSimulation),
+              settingsDispatched: true
+            };
+          } else {
+            advancedEventPayload.simulation = clone(latestSimulation);
+            advancedEventPayload.settingsDispatched = true;
+          }
+          window.dispatchEvent(new CustomEvent('advancedImpactCalculated', { detail: advancedEventPayload }));
 
           const statusEl = document.getElementById('status');
           if (statusEl) {
@@ -621,6 +828,7 @@
             statusEl.textContent = 'Advanced metrics calculation failed';
             statusEl.style.color = 'red';
           }
+          renderDamageMetrics(null, { error: 'Advanced metrics calculation failed. Please try again.' });
         } finally {
           advancedCalculationButton.textContent = originalText;
           advancedCalculationButton.disabled = false;
@@ -768,6 +976,13 @@
             historyButton.style.display = 'none';
             userInfo.style.display = 'none';
         });
+    }
+
+    const defensePlannerButton = document.getElementById('defense-planner-button');
+    if (defensePlannerButton) {
+      defensePlannerButton.addEventListener('click', () => {
+        window.location.href = 'defense-planner.html';
+      });
     }
 
     const settingsPanel = document.getElementById('settingsPanel');

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -386,6 +386,7 @@
     let cachedHistory = [];
 
     const DEFENSE_PLAN_STORAGE_KEY = 'defensePlanner:lastConfiguration';
+    const DEFENSE_PLAN_AUTO_FOLLOW_SOURCES = new Set(['defense-planner', 'storage', 'bootstrap']);
 
     const safeParseJson = (value) => {
       if (typeof value !== 'string' || !value.length) {
@@ -404,11 +405,16 @@
         return;
       }
       window.__latestDefensePlan = plan;
+      const source = meta?.source ?? null;
+      const shouldAutoFollow = typeof meta.autoFollow === 'boolean'
+        ? meta.autoFollow
+        : (source ? DEFENSE_PLAN_AUTO_FOLLOW_SOURCES.has(source) : false);
       window.dispatchEvent(new CustomEvent('defenseStrategyUpdated', {
         detail: {
           plan,
           meta: {
             ...meta,
+            autoFollow: shouldAutoFollow,
             receivedAt: Date.now()
           }
         }

--- a/astroyd-meteor-madness-main/index.html
+++ b/astroyd-meteor-madness-main/index.html
@@ -304,6 +304,13 @@
   <button id="toggleButton">Toggle View</button>
   <button id="cameraToggleButton">Follow Asteroid</button>
   <button id="neoToggleButton" type="button">Show NEOs</button>
+  <div id="defenseOverlayControls" style="position:absolute;top:10px;left:940px;z-index:1000;display:flex;gap:12px;align-items:center;background:rgba(255,255,255,0.85);padding:6px 10px;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,0.15);">
+    <label for="defenseOverlayToggle" style="display:flex;align-items:center;gap:6px;font-size:12px;color:#222;white-space:nowrap;">
+      <input id="defenseOverlayToggle" type="checkbox" style="margin:0;">
+      Show Defense Overlays
+    </label>
+    <button id="replayDefenseButton" type="button" style="padding:6px 12px;border:none;border-radius:4px;background:rgba(33,150,243,0.9);color:#fff;font-size:12px;cursor:pointer;white-space:nowrap;" disabled>Replay Defense Strategy</button>
+  </div>
   <button id="launchButton" type="button">Launch Simulation</button>
   <button id="advanced-calculation" type="button" style="position:absolute;top:10px;left:600px;z-index:1000;padding:10px 20px;background:rgba(34,139,34,0.85);border:none;color:white;cursor:pointer;border-radius:4px;font-size:14px;">Advanced Metrics</button>
   <button id="defense-planner-button" type="button" style="position:absolute;top:10px;left:760px;z-index:1000;padding:10px 20px;background:rgba(123, 31, 162, 0.85);border:none;color:white;cursor:pointer;border-radius:4px;font-size:14px;">Defense Planner</button>
@@ -385,8 +392,45 @@
     const api = new MeteorMadnessAPI();
     let cachedHistory = [];
 
+    const defenseOverlayToggle = document.getElementById('defenseOverlayToggle');
+    const replayDefenseButton = document.getElementById('replayDefenseButton');
+    let defenseOverlayEnabled = false;
+
     const DEFENSE_PLAN_STORAGE_KEY = 'defensePlanner:lastConfiguration';
     const DEFENSE_PLAN_AUTO_FOLLOW_SOURCES = new Set(['defense-planner', 'storage', 'bootstrap']);
+
+    const emitDefenseOverlayPreference = () => {
+      window.defenseOverlayEnabled = defenseOverlayEnabled;
+      window.dispatchEvent(new CustomEvent('defenseOverlayPreferenceChanged', {
+        detail: { enabled: defenseOverlayEnabled }
+      }));
+    };
+
+    const updateDefenseReplayAvailability = (plan) => {
+      if (!replayDefenseButton) {
+        return;
+      }
+      const hasPlan = !!(plan && Array.isArray(plan.loadout) && plan.loadout.length);
+      replayDefenseButton.disabled = !hasPlan;
+    };
+
+    emitDefenseOverlayPreference();
+
+    if (defenseOverlayToggle) {
+      defenseOverlayToggle.checked = defenseOverlayEnabled;
+      defenseOverlayToggle.addEventListener('change', () => {
+        defenseOverlayEnabled = defenseOverlayToggle.checked;
+        emitDefenseOverlayPreference();
+      });
+    }
+
+    if (replayDefenseButton) {
+      replayDefenseButton.addEventListener('click', () => {
+        if (typeof window.replayDefenseVisualization === 'function') {
+          window.replayDefenseVisualization();
+        }
+      });
+    }
 
     const safeParseJson = (value) => {
       if (typeof value !== 'string' || !value.length) {
@@ -402,9 +446,11 @@
 
     const dispatchDefensePlanUpdate = (plan, meta = {}) => {
       if (!plan || typeof plan !== 'object') {
+        updateDefenseReplayAvailability(null);
         return;
       }
       window.__latestDefensePlan = plan;
+      updateDefenseReplayAvailability(plan);
       const source = meta?.source ?? null;
       const shouldAutoFollow = typeof meta.autoFollow === 'boolean'
         ? meta.autoFollow
@@ -549,6 +595,12 @@
       if (event?.detail) {
         renderDamageMetrics(event.detail);
       }
+    });
+
+    window.addEventListener('defenseStrategyUpdated', (event) => {
+      const detail = event?.detail ?? null;
+      const plan = detail?.plan ?? detail ?? null;
+      updateDefenseReplayAvailability(plan);
     });
 
     const renderHistoryTable = (history) => {


### PR DESCRIPTION
## Summary
- merge advanced impact calculation results into the cached simulation and refresh the linked form inputs
- surface returned damage assessment details in the settings panel and update them when advanced metrics finish
- trigger the Cesium scene to refresh when advanced metrics fire events without an accompanying settings update
- add a dedicated Meteor Defense Planner page with level selection, tech upgrades, and leaderboard scoring accessible from the main UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2567b499483228e13bce3f4e78438